### PR TITLE
Reworked the way Goteo gets translations for the admin panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,12 @@
+*~
+
+# ignore local config file, only check-in config.sample.php
+# each deployment is supposed to customize their own config.php
+config.php
+
 data/
 
 # translation binary files
 *.mo
+# IDE project folder
+nbproject/

--- a/TRANSLATOR_NOTES
+++ b/TRANSLATOR_NOTES
@@ -1,5 +1,4 @@
-NOTES OF A FRUSTRATED TRANSLATOR
-Zilog <dropmeaword@gmail.com>
+== Notes about the i18n work
 
 It's wonderful that Goteo is multilingual from the get go. Most texts 
 are saved in the database in several languages and Goteo features a 
@@ -7,29 +6,44 @@ text lookup library to fetch the correct text.
 
 However for some reason this system is not used in the administration
 pages. So no matter which language you set on the selector, the 
-administration panel appears to be in Spanish only. 
-(and the log message too)
+administration panel appears to be in Spanish only. This is far from ideal if
+you want to have a non-spanish instance.
 
-For deployments in non-spanish speaking teams this is not so handy.
-
-I have decided to implement translation of the admin panel using gettext
-beccause it is a reasonably well understood approach and because it 
+I have decided to implement translation of the admin panel using a gettext
+derivative because it is a reasonably well understood approach and because it
 doesn't use the database. Also, having a standard way of tagging 
 language dependant texts directly in the source code has the positive 
-effect of being almost sellf documenting.
+effect of being almost self documenting.
 
-The index.php file is the global dispatcher and I have also made it
-language aware so that the correct env variables are set for gettext to 
-function correctly. This is the bit of code that does the magic.
+At the moment Goteo has two approaches to fetch language specific texts:
 
-$lang = "en_EN";
-if (isset($_GET['lang'])) 
-	$lang = $_GET['lang'];
-putenv("LC_ALL=$lang");
-setlocale(LC_ALL, $lang);
-bindtextdomain("messages", "locale");
-bind_textdomain_codeset('messages', 'UTF-8');
-textdomain("messages");
+1. Through Text::get('text_id') which fetches the text from the database.
+This is used pretty widely in Goteo and uses the built-in translation mechanism
+accessible through the admin panel.
 
-See http://www.codeforest.net/translate-and-localize-your-web-application-with-php-and-gettext
-for further details on how to make your PHP web app multilingual.
+2.Through Text::_("Text to fetch") which is an implementation based on gettext .po
+files, which is a widely standard. Provides more direct understanding of the code
+(messages are looked up by content, not by a reference id).
+
+Having two systems is far from ideal, but while a decission is made which way to
+go at least the current implementation includes an admin panel that is not only
+in Spanish.
+
+If you want to create your own translation of the admin panel you can start
+by editing the file in locale/en_GB/messages.po with PoEdit (or similar tool
+for translators). And saving it under the correct locale for your language. For
+example if you translate the messages.po file to Greek. The resulting file should
+be saved to locale/el_GR/messages.po
+
+To have your language available in the language selector on the top right you
+have to add it and enable it in the database. For example, if you want to add
+Greek, you can do so by running the following query in your database.
+
+INSERT INTO `lang` VALUES('el', 'Greek', 1, 'ελληνικά', 'el_GR');
+
+That's all there is to it.
+
+You can contribute to the full internationalization of Goteo in several ways.
+The simplest is by translating the current .po file into your language. But an
+even better way of helping out is by tagging all the hardcoded-spanish text you
+encounter with the Text::_() call.

--- a/config.sample.php
+++ b/config.sample.php
@@ -80,18 +80,30 @@ define('GOTEO_MAIL_SMTP_PASSWORD', '');
 
 define('GOTEO_MAIL', 'hola@goteo.org');
 
+$config['locale'] = array(
+	// default interface language
+	'default_language' => 'en',
+	// root directory of language files (relative to root of Goteo install)
+	'gettext_root' => 'locale',
+	// name of the gettext .po file (used for admin only texts at the moment)
+	'gettext_domain' => 'messages',
+	// gettext files are cached, to reload a new one requires to restart Apache which is stupid (and annoying while
+	//	developing) this setting tells the langueage code to bypass caching by using a clever file-renaming
+	// mechanism described in http://blog.ghost3k.net/articles/php/11/gettext-caching-in-php
+	'gettext_bypass_caching' => false,
+	// use php implementation (true) or apache module (false)?
+	// See this blogpost to understand why using the apache module is not a good idea
+	// unles you really know what you are doing
+	// http://blog.spinningkid.info/?p=2025
+	'gettext_use_php_implementation' => true
+);
+
 // Language
-define('GOTEO_DEFAULT_LANG', 'en');
-// name of the gettext .po file (used for admin only texts at the moment)
-define('GOTEO_GETTEXT_DOMAIN', 'messages');
-// gettext files are cached, to reload a new one requires to restart Apache which is stupid (and annoying while 
-//	developing) this setting tells the langueage code to bypass caching by using a clever file-renaming 
-// mechanism described in http://blog.ghost3k.net/articles/php/11/gettext-caching-in-php
-define('GOTEO_GETTEXT_BYPASS_CACHING', true);
+define('GOTEO_DEFAULT_LANG', $config['locale']['default_language']);
 
 // url
-define('SITE_URL', 'http://localhost:8888/');
-define('SRC_URL', 'http://localhost:8888/');
+define('SITE_URL', 'http://localhost:8080/');
+define('SRC_URL', 'http://localhost:8080/');
 
 // Cron params
 define('CRON_PARAM', '');

--- a/controller/admin.php
+++ b/controller/admin.php
@@ -190,25 +190,25 @@ namespace Goteo\Controller {
                             'data' => $data,
                             'columns' => array(
                                 'edit' => '',
-                                'text' => _('Texto'),
-                                'group' => _('Agrupación')
+                                'text' => Text::_('Texto'),
+                                'group' => Text::_('Agrupación')
                             ),
                             'url' => '/admin/texts',
                             'filters' => array(
                                 'idfilter' => array(
-                                        'label'   => _('Filtrar por tipo:'),
+                                        'label'   => Text::_('Filtrar por tipo:'),
                                         'type'    => 'select',
                                         'options' => $idfilters,
                                         'value'   => $filters['idfilter']
                                     ),
                                 'group' => array(
-                                        'label'   => _('Filtrar por agrupación:'),
+                                        'label'   => Text::_('Filtrar por agrupación:'),
                                         'type'    => 'select',
                                         'options' => $groups,
                                         'value'   => $filters['group']
                                     ),
                                 'text' => array(
-                                        'label'   => _('Buscar texto:'),
+                                        'label'   => Text::_('Buscar texto:'),
                                         'type'    => 'input',
                                         'options' => null,
                                         'value'   => $filters['text']
@@ -255,18 +255,18 @@ namespace Goteo\Controller {
                                 'action' => '/admin/texts/edit/'.$id.'/'.$filter,
                                 'submit' => array(
                                     'name' => 'update',
-                                    'label' => _('Aplicar')
+                                    'label' => Text::_('Aplicar')
                                 ),
                                 'fields' => array (
                                     'idtext' => array(
-                                        'label' => _(''),
+                                        'label' => Text::_(''),
                                         'name' => 'id',
                                         'type' => 'hidden',
                                         'properties' => '',
 
                                     ),
                                     'newtext' => array(
-                                        'label' => _('Texto'),
+                                        'label' => Text::_('Texto'),
                                         'name' => 'text',
                                         'type' => 'textarea',
                                         'properties' => 'cols="100" rows="6"',
@@ -403,9 +403,9 @@ namespace Goteo\Controller {
                     try {
                         $sql = "UPDATE project SET " . $set . " WHERE id = :id";
                         if (Model\Project::query($sql, $values)) {
-                            $log_text = _('El admin %s ha <span class="red">tocado las fechas</span> del proyecto %s');
+                            $log_text = Text::_('El admin %s ha <span class="red">tocado las fechas</span> del proyecto %s');
                         } else {
-                            $log_text = _('Al admin %s le ha <span class="red">fallado al tocar las fechas</span> del proyecto %s');
+                            $log_text = Text::_('Al admin %s le ha <span class="red">fallado al tocar las fechas</span> del proyecto %s');
                         }
                     } catch(\PDOException $e) {
                         $errors[] = _("No se ha guardado correctamente. ") . $e->getMessage();
@@ -416,7 +416,7 @@ namespace Goteo\Controller {
                     $accounts->bank = $_POST['bank'];
                     $accounts->paypal = $_POST['paypal'];
                     if ($accounts->save($errors)) {
-                        $errors[] = _('Se han actualizado las cuentas del proyecto ').$_POST['id'];
+                        $errors[] = Text::_('Se han actualizado las cuentas del proyecto ').$_POST['id'];
                     }
 
                 }
@@ -436,49 +436,49 @@ namespace Goteo\Controller {
                 case 'review':
                     // pasar un proyecto a revision
                     if ($project->ready($errors)) {
-                        $log_text = _('El admin %s ha pasado el proyecto %s al estado <span class="red">Revisión</span>');
+                        $log_text = Text::_('El admin %s ha pasado el proyecto %s al estado <span class="red">Revisión</span>');
                     } else {
-                        $log_text = _('Al admin %s le ha fallado al pasar el proyecto %s al estado <span class="red">Revisión</span>');
+                        $log_text = Text::_('Al admin %s le ha fallado al pasar el proyecto %s al estado <span class="red">Revisión</span>');
                     }
                     break;
                 case 'publish':
                     // poner un proyecto en campaña
                     if ($project->publish($errors)) {
-                        $log_text = _('El admin %s ha pasado el proyecto %s al estado <span class="red">en Campaña</span>');
+                        $log_text = Text::_('El admin %s ha pasado el proyecto %s al estado <span class="red">en Campaña</span>');
                     } else {
-                        $log_text = _('Al admin %s le ha fallado al pasar el proyecto %s al estado <span class="red">en Campaña</span>');
+                        $log_text = Text::_('Al admin %s le ha fallado al pasar el proyecto %s al estado <span class="red">en Campaña</span>');
                     }
                     break;
                 case 'cancel':
                     // descartar un proyecto por malo
                     if ($project->cancel($errors)) {
-                        $log_text = _('El admin %s ha pasado el proyecto %s al estado <span class="red">Descartado</span>');
+                        $log_text = Text::_('El admin %s ha pasado el proyecto %s al estado <span class="red">Descartado</span>');
                     } else {
-                        $log_text = _('Al admin %s le ha fallado al pasar el proyecto %s al estado <span class="red">Descartado</span>');
+                        $log_text = Text::_('Al admin %s le ha fallado al pasar el proyecto %s al estado <span class="red">Descartado</span>');
                     }
                     break;
                 case 'enable':
                     // si no está en edición, recuperarlo
                     if ($project->enable($errors)) {
-                        $log_text = _('El admin %s ha pasado el proyecto %s al estado <span class="red">Edición</span>');
+                        $log_text = Text::_('El admin %s ha pasado el proyecto %s al estado <span class="red">Edición</span>');
                     } else {
-                        $log_text = _('Al admin %s le ha fallado al pasar el proyecto %s al estado <span class="red">Edición</span>');
+                        $log_text = Text::_('Al admin %s le ha fallado al pasar el proyecto %s al estado <span class="red">Edición</span>');
                     }
                     break;
                 case 'complete':
                     // dar un proyecto por financiado manualmente
                     if ($project->succeed($errors)) {
-                        $log_text = _('El admin %s ha pasado el proyecto %s al estado <span class="red">Financiado</span>');
+                        $log_text = Text::_('El admin %s ha pasado el proyecto %s al estado <span class="red">Financiado</span>');
                     } else {
-                        $log_text = _('Al admin %s le ha fallado al pasar el proyecto %s al estado <span class="red">Financiado</span>');
+                        $log_text = Text::_('Al admin %s le ha fallado al pasar el proyecto %s al estado <span class="red">Financiado</span>');
                     }
                     break;
                 case 'fulfill':
                     // marcar que el proyecto ha cumplido con los retornos colectivos
                     if ($project->satisfied($errors)) {
-                        $log_text = _('El admin %s ha pasado el proyecto %s al estado <span class="red">Retorno cumplido</span>');
+                        $log_text = Text::_('El admin %s ha pasado el proyecto %s al estado <span class="red">Retorno cumplido</span>');
                     } else {
-                        $log_text = _('Al admin %s le ha fallado al pasar el proyecto %s al estado <span class="red">Retorno cumplido</span>');
+                        $log_text = Text::_('Al admin %s le ha fallado al pasar el proyecto %s al estado <span class="red">Retorno cumplido</span>');
                     }
                     break;
             }
@@ -488,7 +488,7 @@ namespace Goteo\Controller {
                  * Evento Feed
                  */
                 $log = new Feed();
-                $log->title = _('Cambio estado/fechas de un proyecto desde el admin');
+                $log->title = Text::_('Cambio estado/fechas de un proyecto desde el admin');
                 $log->url = '/admin/projects';
                 $log->type = 'admin';
                 $log_items = array(
@@ -554,8 +554,8 @@ namespace Goteo\Controller {
             $categories = Model\Project\Category::getAll();
             $owners = Model\User::getOwners();
             $orders = array(
-                'name' => _('Nombre'),
-                'updated' => _('Enviado a revision')
+                'name' => Text::_('Nombre'),
+                'updated' => Text::_('Enviado a revision')
             );
 
             return new View(
@@ -621,16 +621,16 @@ namespace Goteo\Controller {
                         if ($review->save($errors)) {
                             switch ($action) {
                                 case 'add':
-                                    $success[] = _('Revisión iniciada correctamente');
+                                    $success[] = Text::_('Revisión iniciada correctamente');
 
                                     /*
                                      * Evento Feed
                                      */
                                     $log = new Feed();
-                                    $log->title = _('valoración iniciada (admin)');
+                                    $log->title = Text::_('valoración iniciada (admin)');
                                     $log->url = '/admin/reviews';
                                     $log->type = 'admin';
-                                    $log_text = _('El admin %s ha %s la valoración de %s');
+                                    $log_text = Text::_('El admin %s ha %s la valoración de %s');
                                     $log_items = array(
                                         Feed::item('user', $_SESSION['user']->name, $_SESSION['user']->id),
                                         Feed::item('relevant', 'Iniciado'),
@@ -643,7 +643,7 @@ namespace Goteo\Controller {
 
                                     break;
                                 case 'edit':
-                                    $success[] = _('Datos editados correctamente');
+                                    $success[] = Text::_('Datos editados correctamente');
                                     break;
                             }
                             
@@ -671,19 +671,19 @@ namespace Goteo\Controller {
 
                     // marcamos la revision como completamente cerrada
                     if (Model\Review::close($id, $errors)) {
-                        $message = _('La revisión se ha cerrado');
+                        $message = Text::_('La revisión se ha cerrado');
 
                         /*
                          * Evento Feed
                          */
                         $log = new Feed();
-                        $log->title = _('valoración finalizada (admin)');
+                        $log->title = Text::_('valoración finalizada (admin)');
                         $log->url = '/admin/reviews';
                         $log->type = 'admin';
-                        $log_text = _('El admin %s ha dado por %s la valoración de %s');
+                        $log_text = Text::_('El admin %s ha dado por %s la valoración de %s');
                         $log_items = array(
                             Feed::item('user', $_SESSION['user']->name, $_SESSION['user']->id),
-                            Feed::item('relevant', _('Finalizada')),
+                            Feed::item('relevant', Text::_('Finalizada')),
                             Feed::item('project', $review->name, $review->project)
                         );
                         $log->html = \vsprintf($log_text, $log_items);
@@ -725,13 +725,13 @@ namespace Goteo\Controller {
                              * Evento Feed
                              */
                             $log = new Feed();
-                            $log->title = _('asignar revision (admin)');
+                            $log->title = Text::_('asignar revision (admin)');
                             $log->url = '/admin/reviews';
                             $log->type = 'admin';
-                            $log_text = _('El admin %s ha %s a %s la revisión de %s');
+                            $log_text = Text::_('El admin %s ha %s a %s la revisión de %s');
                             $log_items = array(
                                 Feed::item('user', $_SESSION['user']->name, $_SESSION['user']->id),
-                                Feed::item('relevant', _('Asignado')),
+                                Feed::item('relevant', Text::_('Asignado')),
                                 Feed::item('user', $userData->name, $userData->id),
                                 Feed::item('project', $reviewData->name, $reviewData->project)
                             );
@@ -762,13 +762,13 @@ namespace Goteo\Controller {
                              * Evento Feed
                              */
                             $log = new Feed();
-                            $log->title = _('asignar revision (admin)');
+                            $log->title = Text::_('asignar revision (admin)');
                             $log->url = '/admin/reviews';
                             $log->type = 'admin';
-                            $log_text = _('El admin %s ha %s a %s la revisión de %s');
+                            $log_text = Text::_('El admin %s ha %s a %s la revisión de %s');
                             $log_items = array(
                                 Feed::item('user', $_SESSION['user']->name, $_SESSION['user']->id),
-                                Feed::item('relevant', _('Desasignado')),
+                                Feed::item('relevant', Text::_('Desasignado')),
                                 Feed::item('user', $userData->name, $userData->id),
                                 Feed::item('project', $reviewData->name, $reviewData->project)
                             );
@@ -807,8 +807,8 @@ namespace Goteo\Controller {
 
             $projects = Model\Review::getList($filters);
             $status = array(
-                'open' => _('Abiertas'),
-                'closed' => _('Cerradas')
+                'open' => Text::_('Abiertas'),
+                'closed' => Text::_('Cerradas')
             );
             $checkers = Model\User::getAll(array('role'=>'checker'));
 
@@ -871,7 +871,7 @@ namespace Goteo\Controller {
                     if (!empty($id)) {
                         $project = Model\Project::getMini($id);
                     } elseif ($action != 'add') {
-                        Message::Error(_('No hay proyecto sobre el que operar'));
+                        Message::Error(Text::_('No hay proyecto sobre el que operar'));
                         throw new Redirection('/admin/translates');
                     }
 
@@ -890,11 +890,11 @@ namespace Goteo\Controller {
                         switch ($action) {
                             case 'assign': // se la ponemos
                                 $assignation->save($errors);
-                                $what = _('Asignado');
+                                $what = Text::_('Asignado');
                                 break;
                             case 'unassign': // se la quitamos
                                 $assignation->remove($errors);
-                                $what = _('Desasignado');
+                                $what = Text::_('Desasignado');
                                 break;
                         }
 
@@ -903,10 +903,10 @@ namespace Goteo\Controller {
                              * Evento Feed
                              */
                             $log = new Feed();
-                            $log->title = $what . _(' traduccion (admin)');
+                            $log->title = $what . Text::_(' traduccion (admin)');
                             $log->url = '/admin/reviews';
                             $log->type = 'admin';
-                            $log_text = _('El admin %s ha %s a %s la traducción del proyecto %s');
+                            $log_text = Text::_('El admin %s ha %s a %s la traducción del proyecto %s');
                             $log_items = array(
                                 Feed::item('user', $_SESSION['user']->name, $_SESSION['user']->id),
                                 Feed::item('relevant', $what),
@@ -933,20 +933,20 @@ namespace Goteo\Controller {
                         // ponemos los datos que llegan
                         $sql = "UPDATE project SET lang = :lang, translate = 1 WHERE id = :id";
                         if (Model\Project::query($sql, array(':lang'=>$_POST['lang'], ':id'=>$id))) {
-                            $success[] = ($action == 'add') ? _('El proyecto ').$project->name._(' se ha habilitado para traducir') : _('Datos de traducción actualizados');
+                            $success[] = ($action == 'add') ? Text::_('El proyecto ').$project->name.Text::_(' se ha habilitado para traducir') : Text::_('Datos de traducción actualizados');
 
                             if ($action == 'add') {
                                 /*
                                  * Evento Feed
                                  */
                                 $log = new Feed();
-                                $log->title = _('proyecto habilitado para traducirse (admin)');
+                                $log->title = Text::_('proyecto habilitado para traducirse (admin)');
                                 $log->url = '/admin/translates';
                                 $log->type = 'admin';
-                                $log_text = _('El admin %s ha %s la traducción del proyecto %s');
+                                $log_text = Text::_('El admin %s ha %s la traducción del proyecto %s');
                                 $log_items = array(
                                     Feed::item('user', $_SESSION['user']->name, $_SESSION['user']->id),
-                                    Feed::item('relevant', _('Habilitado')),
+                                    Feed::item('relevant', Text::_('Habilitado')),
                                     Feed::item('project', $project->name, $project->id)
                                 );
                                 $log->html = \vsprintf($log_text, $log_items);
@@ -957,7 +957,7 @@ namespace Goteo\Controller {
                                 $action = 'edit';
                             }
                         } else {
-                            $errors[] = _('Ha fallado al habilitar la traducción del proyecto ') . $project->name;
+                            $errors[] = Text::_('Ha fallado al habilitar la traducción del proyecto ') . $project->name;
                         }
                     }
 
@@ -981,9 +981,9 @@ namespace Goteo\Controller {
                         $mailHandler->html = true;
                         $mailHandler->template = $template->id;
                         if ($mailHandler->send()) {
-                            $success[] = _('Se ha enviado un email a').'<strong>'.$project->user->name.'</strong>'._('a la dirección').'<strong>'.$project->user->email.'</strong>';
+                            $success[] = Text::_('Se ha enviado un email a').'<strong>'.$project->user->name.'</strong>'.Text::_('a la dirección').'<strong>'.$project->user->email.'</strong>';
                         } else {
-                            $errors[] = _('Ha fallado informar a').' <strong>'.$project->user->name.'</strong> '._('de la posibilidad de traducción de su proyecto');
+                            $errors[] = Text::_('Ha fallado informar a').' <strong>'.$project->user->name.'</strong> '.Text::_('de la posibilidad de traducción de su proyecto');
                         }
                         unset($mailHandler);
                         $action = 'edit';
@@ -1017,7 +1017,7 @@ namespace Goteo\Controller {
                     // el campo translate del proyecto $id a false
                     $sql = "UPDATE project SET translate = 0 WHERE id = :id";
                     if (Model\Project::query($sql, array(':id'=>$id))) {
-                        $success[] = _('La traducción del proyecto ').$project->name._(' se ha finalizado');
+                        $success[] = Text::_('La traducción del proyecto ').$project->name.Text::_(' se ha finalizado');
 
                         Model\Project::query("DELETE FROM user_translate WHERE project = :id", array(':id'=>$id));
 
@@ -1025,10 +1025,10 @@ namespace Goteo\Controller {
                          * Evento Feed
                          */
                         $log = new Feed();
-                        $log->title = _('traducción finalizada (admin)');
+                        $log->title = Text::_('traducción finalizada (admin)');
                         $log->url = '/admin/translates';
                         $log->type = 'admin';
-                        $log_text = _('El admin %s ha dado por %s la traducción de %s');
+                        $log_text = Text::_('El admin %s ha dado por %s la traducción de %s');
                         $log_items = array(
                             Feed::item('user', $_SESSION['user']->name, $_SESSION['user']->id),
                             Feed::item('relevant', 'Finalizada'),
@@ -1039,7 +1039,7 @@ namespace Goteo\Controller {
 
                         unset($log);
                     } else {
-                        $errors[] = _('Falló al finalizar la traducción');
+                        $errors[] = Text::_('Falló al finalizar la traducción');
                     }
                     break;
             }
@@ -1095,7 +1095,7 @@ namespace Goteo\Controller {
 				if ($promo->save($errors)) {
                     switch ($_POST['action']) {
                         case 'add':
-                            $success[] = _('Proyecto destacado correctamente');
+                            $success[] = Text::_('Proyecto destacado correctamente');
 
                             $projectData = Model\Project::getMini($_POST['project']);
 
@@ -1103,13 +1103,13 @@ namespace Goteo\Controller {
                              * Evento Feed
                              */
                             $log = new Feed();
-                            $log->title = _('nuevo proyecto destacado en portada (admin)');
+                            $log->title = Text::_('nuevo proyecto destacado en portada (admin)');
                             $log->url = '/admin/promote';
                             $log->type = 'admin';
-                            $log_text = _('El admin %s ha %s el proyecto %s');
+                            $log_text = Text::_('El admin %s ha %s el proyecto %s');
                             $log_items = array(
                                 Feed::item('user', $_SESSION['user']->name, $_SESSION['user']->id),
-                                Feed::item('relevant', _('Destacado en portada'), '/'),
+                                Feed::item('relevant', Text::_('Destacado en portada'), '/'),
                                 Feed::item('project', $projectData->name, $projectData->id)
                             );
                             $log->html = \vsprintf($log_text, $log_items);
@@ -1119,7 +1119,7 @@ namespace Goteo\Controller {
 
                             break;
                         case 'edit':
-                            $success[] = _('Destacado actualizado correctamente');
+                            $success[] = Text::_('Destacado actualizado correctamente');
                             break;
                     }
 				}
@@ -1183,13 +1183,13 @@ namespace Goteo\Controller {
                          * Evento Feed
                          */
                         $log = new Feed();
-                        $log->title = _('proyecto quitado portada (admin)');
+                        $log->title = Text::_('proyecto quitado portada (admin)');
                         $log->url = '/admin/promote';
                         $log->type = 'admin';
-                        $log_text = _('El admin %s ha %s el proyecto %s');
+                        $log_text = Text::_('El admin %s ha %s el proyecto %s');
                         $log_items = array(
                             Feed::item('user', $_SESSION['user']->name, $_SESSION['user']->id),
-                            Feed::item('relevant', _('Quitado de la portada')),
+                            Feed::item('relevant', Text::_('Quitado de la portada')),
                             Feed::item('project', $projectData->name, $projectData->id)
                         );
                         $log->html = \vsprintf($log_text, $log_items);
@@ -1197,7 +1197,7 @@ namespace Goteo\Controller {
 
                         unset($log);
 
-                        $success[] = _('Proyecto quitado correctamente');
+                        $success[] = Text::_('Proyecto quitado correctamente');
                     }
                     break;
                 case 'add':
@@ -1278,7 +1278,7 @@ namespace Goteo\Controller {
                 }
 
 				if ($banner->save($errors)) {
-                    $success[] = _('Datos guardados');
+                    $success[] = Text::_('Datos guardados');
 
                     if ($_POST['action'] == 'add') {
                         $projectData = Model\Project::getMini($_POST['project']);
@@ -1287,13 +1287,13 @@ namespace Goteo\Controller {
                          * Evento Feed
                          */
                         $log = new Feed();
-                        $log->title = _('nuevo banner de proyecto destacado en portada (admin)');
+                        $log->title = Text::_('nuevo banner de proyecto destacado en portada (admin)');
                         $log->url = '/admin/promote';
                         $log->type = 'admin';
-                        $log_text = _('El admin %s ha %s del proyecto %s');
+                        $log_text = Text::_('El admin %s ha %s del proyecto %s');
                         $log_items = array(
                             Feed::item('user', $_SESSION['user']->name, $_SESSION['user']->id),
-                            Feed::item('relevant', _('Publicado un banner'), '/'),
+                            Feed::item('relevant', Text::_('Publicado un banner'), '/'),
                             Feed::item('project', $projectData->name, $projectData->id)
                         );
                         $log->html = \vsprintf($log_text, $log_items);
@@ -1349,13 +1349,13 @@ namespace Goteo\Controller {
                          * Evento Feed
                          */
                         $log = new Feed();
-                        $log->title = _('banner de proyecto quitado portada (admin)');
+                        $log->title = Text::_('banner de proyecto quitado portada (admin)');
                         $log->url = '/admin/promote';
                         $log->type = 'admin';
-                        $log_text = _('El admin %s ha %s del proyecto %s');
+                        $log_text = Text::_('El admin %s ha %s del proyecto %s');
                         $log_items = array(
                             Feed::item('user', $_SESSION['user']->name, $_SESSION['user']->id),
-                            Feed::item('relevant', _('Quitado el banner'), '/'),
+                            Feed::item('relevant', Text::_('Quitado el banner'), '/'),
                             Feed::item('project', $projectData->name, $projectData->id)
                         );
                         $log->html = \vsprintf($log_text, $log_items);
@@ -1451,10 +1451,10 @@ namespace Goteo\Controller {
 				if ($faq->save($errors)) {
                     switch ($_POST['action']) {
                         case 'add':
-                            $success = _('Pregunta añadida correctamente');
+                            $success = Text::_('Pregunta añadida correctamente');
                             break;
                         case 'edit':
-                            $success = _('Pregunta editado correctamente');
+                            $success = Text::_('Pregunta editado correctamente');
                             break;
                     }
 				}
@@ -1576,10 +1576,10 @@ namespace Goteo\Controller {
 				if ($criteria->save($errors)) {
                     switch ($_POST['action']) {
                         case 'add':
-                            $success = _('Criterio añadido correctamente');
+                            $success = Text::_('Criterio añadido correctamente');
                             break;
                         case 'edit':
-                            $success = _('Criterio editado correctamente');
+                            $success = Text::_('Criterio editado correctamente');
                             break;
                     }
 				}
@@ -1700,16 +1700,16 @@ namespace Goteo\Controller {
 				if ($icon->save($errors)) {
                     switch ($_POST['action']) {
                         case 'add':
-                            $success = _('Nuevo tipo añadido correctamente');
+                            $success = Text::_('Nuevo tipo añadido correctamente');
                             break;
                         case 'edit':
-                            $success = _('Tipo editado correctamente');
+                            $success = Text::_('Tipo editado correctamente');
 
                             /*
                              * Evento Feed
                              */
                             $log = new Feed();
-                            $log->title = _('modificacion de tipo de retorno/recompensa (admin)');
+                            $log->title = Text::_('modificacion de tipo de retorno/recompensa (admin)');
                             $log->url = '/admin/icons';
                             $log->type = 'admin';
                             $log_text = _("El admin %s ha %s el tipo de retorno/recompensa %s");
@@ -1848,16 +1848,16 @@ namespace Goteo\Controller {
 				if ($license->save($errors)) {
                     switch ($_POST['action']) {
                         case 'add':
-                            $success = _('Licencia añadida correctamente');
+                            $success = Text::_('Licencia añadida correctamente');
                             break;
                         case 'edit':
-                            $success = _('Licencia editada correctamente');
+                            $success = Text::_('Licencia editada correctamente');
 
                             /*
                              * Evento Feed
                              */
                             $log = new Feed();
-                            $log->title = _('modificacion de licencia (admin)');
+                            $log->title = Text::_('modificacion de licencia (admin)');
                             $log->url = '/admin/licenses';
                             $log->type = 'admin';
                             $log_text = _("El admin %s ha %s la licencia %s");
@@ -1979,7 +1979,7 @@ namespace Goteo\Controller {
                 ));
 
 				if ($post->update($errors)) {
-                    $success[] = _('Entrada colocada en la portada correctamente');
+                    $success[] = Text::_('Entrada colocada en la portada correctamente');
 				}
 				else {
                     return new View(
@@ -2066,7 +2066,7 @@ namespace Goteo\Controller {
                 ));
 
 				if ($post->update($errors)) {
-                    $success[] = _('Entrada colocada en el footer correctamente');
+                    $success[] = Text::_('Entrada colocada en el footer correctamente');
 				}
 				else {
                     return new View(
@@ -2158,22 +2158,22 @@ namespace Goteo\Controller {
                                 'action' => "$url/edit/",
                                 'submit' => array(
                                     'name' => 'update',
-                                    'label' => _('Añadir')
+                                    'label' => Text::_('Añadir')
                                 ),
                                 'fields' => array (
                                     'id' => array(
-                                        'label' => _(''),
+                                        'label' => Text::_(''),
                                         'name' => 'id',
                                         'type' => 'hidden'
 
                                     ),
                                     'name' => array(
-                                        'label' => _('Categoría'),
+                                        'label' => Text::_('Categoría'),
                                         'name' => 'name',
                                         'type' => 'text'
                                     ),
                                     'description' => array(
-                                        'label' => _('Descripción'),
+                                        'label' => Text::_('Descripción'),
                                         'name' => 'description',
                                         'type' => 'textarea',
                                         'properties' => 'cols="100" rows="2"',
@@ -2227,12 +2227,12 @@ namespace Goteo\Controller {
 
                                     ),
                                     'name' => array(
-                                        'label' => _('Categoría'),
+                                        'label' => Text::_('Categoría'),
                                         'name' => 'name',
                                         'type' => 'text'
                                     ),
                                     'description' => array(
-                                        'label' => _('Descripción'),
+                                        'label' => Text::_('Descripción'),
                                         'name' => 'description',
                                         'type' => 'textarea',
                                         'properties' => 'cols="100" rows="2"',
@@ -2265,14 +2265,14 @@ namespace Goteo\Controller {
                     'folder' => 'base',
                     'file' => 'list',
                     'model' => 'category',
-                    'addbutton' => _('Nueva categoría'),
+                    'addbutton' => Text::_('Nueva categoría'),
                     'data' => $model::getAll(),
                     'columns' => array(
                         'edit' => '',
-                        'name' => _('Categoría'),
-                        'numProj' => _('Proyectos'),
-                        'numUser' => _('Usuarios'),
-                        'order' => _('Prioridad'),
+                        'name' => Text::_('Categoría'),
+                        'numProj' => Text::_('Proyectos'),
+                        'numUser' => Text::_('Usuarios'),
+                        'order' => Text::_('Prioridad'),
                         'translate' => '',
                         'up' => '',
                         'down' => '',
@@ -2317,7 +2317,7 @@ namespace Goteo\Controller {
                                 'action' => "$url/edit/",
                                 'submit' => array(
                                     'name' => 'update',
-                                    'label' => _('Añadir')
+                                    'label' => Text::_('Añadir')
                                 ),
                                 'fields' => array (
                                     'id' => array(
@@ -2327,7 +2327,7 @@ namespace Goteo\Controller {
 
                                     ),
                                     'name' => array(
-                                        'label' => _('Tag'),
+                                        'label' => Text::_('Tag'),
                                         'name' => 'name',
                                         'type' => 'text'
                                     )
@@ -2373,13 +2373,13 @@ namespace Goteo\Controller {
                                 ),
                                 'fields' => array (
                                     'id' => array(
-                                        'label' => _(''),
+                                        'label' => Text::_(''),
                                         'name' => 'id',
                                         'type' => 'hidden'
 
                                     ),
                                     'name' => array(
-                                        'label' => _('Tag'),
+                                        'label' => Text::_('Tag'),
                                         'name' => 'name',
                                         'type' => 'text'
                                     )
@@ -2404,7 +2404,7 @@ namespace Goteo\Controller {
                     'folder' => 'base',
                     'file' => 'list',
                     'model' => 'tag',
-                    'addbutton' => _('Nuevo tag'),
+                    'addbutton' => Text::_('Nuevo tag'),
                     'data' => $model::getList(1),
                     'columns' => array(
                         'edit' => '',
@@ -2506,10 +2506,10 @@ namespace Goteo\Controller {
                              * Evento Feed
                              */
                             $log = new Feed();
-                            $log->title = _('Operación sobre usuario (admin)');
+                            $log->title = Text::_('Operación sobre usuario (admin)');
                             $log->url = '/admin/users';
                             $log->type = 'user';
-                            $log_text = _('El admin %s ha %s del usuario %s');
+                            $log_text = Text::_('El admin %s ha %s del usuario %s');
                             $log_items = array(
                                 Feed::item('user', $_SESSION['user']->name, $_SESSION['user']->id),
                                 Feed::item('relevant', 'Tocado ' . implode (' y ', $tocado)),
@@ -2522,7 +2522,7 @@ namespace Goteo\Controller {
 
 
                             // mensaje de ok y volvemos a la lista de usuarios
-                            Message::Info(_('Datos actualizados'));
+                            Message::Info(Text::_('Datos actualizados'));
                             throw new Redirection('/admin/users');
                             
                         } else {
@@ -2553,43 +2553,43 @@ namespace Goteo\Controller {
                     switch ($subaction)  {
                         case 'ban':
                             $sql = "UPDATE user SET active = 0 WHERE id = :user";
-                            $log_action = _('Desactivado');
+                            $log_action = Text::_('Desactivado');
                             break;
                         case 'unban':
                             $sql = "UPDATE user SET active = 1 WHERE id = :user";
-                            $log_action = _('Activado');
+                            $log_action = Text::_('Activado');
                             break;
                         case 'show':
                             $sql = "UPDATE user SET hide = 0 WHERE id = :user";
-                            $log_action = _('Mostrado');
+                            $log_action = Text::_('Mostrado');
                             break;
                         case 'hide':
                             $sql = "UPDATE user SET hide = 1 WHERE id = :user";
-                            $log_action = _('Ocultado');
+                            $log_action = Text::_('Ocultado');
                             break;
                         case 'checker':
                             $sql = "REPLACE INTO user_role (user_id, role_id) VALUES (:user, 'checker')";
-                            $log_action = _('Hecho revisor');
+                            $log_action = Text::_('Hecho revisor');
                             break;
                         case 'nochecker':
                             $sql = "DELETE FROM user_role WHERE role_id = 'checker' AND user_id = :user";
-                            $log_action = _('Quitado de revisor');
+                            $log_action = Text::_('Quitado de revisor');
                             break;
                         case 'translator':
                             $sql = "REPLACE INTO user_role (user_id, role_id) VALUES (:user, 'translator')";
-                            $log_action = _('Hecho traductor');
+                            $log_action = Text::_('Hecho traductor');
                             break;
                         case 'notranslator':
                             $sql = "DELETE FROM user_role WHERE role_id = 'translator' AND user_id = :user";
-                            $log_action = _('Quitado de traductor');
+                            $log_action = Text::_('Quitado de traductor');
                             break;
                         case 'admin':
                             $sql = "REPLACE INTO user_role (user_id, role_id) VALUES (:user, 'admin')";
-                            $log_action = _('Hecho admin');
+                            $log_action = Text::_('Hecho admin');
                             break;
                         case 'noadmin':
                             $sql = "DELETE FROM user_role WHERE role_id = 'admin' AND user_id = :user";
-                            $log_action = _('Quitado de admin');
+                            $log_action = Text::_('Quitado de admin');
                             break;
                     }
 
@@ -2604,7 +2604,7 @@ namespace Goteo\Controller {
                             $msgi = _("Ha <strong>%s</strong> al usuario <strong>%s</strong> CORRECTAMENTE");
                             $msgi = sprintf($msgi, $log_action, $user->name);
                             Message::Info( $msgi );
-                            $log_text = _('El admin %s ha %s al usuario %s');
+                            $log_text = Text::_('El admin %s ha %s al usuario %s');
 
                         } else {
 
@@ -2620,7 +2620,7 @@ namespace Goteo\Controller {
                          * Evento Feed
                          */
                         $log = new Feed();
-                        $log->title = _('Operación sobre usuario (admin)');
+                        $log->title = Text::_('Operación sobre usuario (admin)');
                         $log->url = '/admin/users';
                         $log->type = 'user';
                         $log_items = array(
@@ -2711,18 +2711,18 @@ namespace Goteo\Controller {
                 default:
                     $users = Model\User::getAll($filters);
                     $status = array(
-                                'active' => _('Activo'),
-                                'inactive' => _('Inactivo')
+                                'active' => Text::_('Activo'),
+                                'inactive' => Text::_('Inactivo')
                             );
                     $interests = Model\User\Interest::getAll();
                     $roles = array(
-                        'admin' => _('Administrador'),
-                        'checker' => _('Revisor'),
-                        'translator' => _('Traductor')
+                        'admin' => Text::_('Administrador'),
+                        'checker' => Text::_('Revisor'),
+                        'translator' => Text::_('Traductor')
                     );
                     $orders = array(
-                        'created' => _('Fecha de alta'),
-                        'name' => _('Nombre')
+                        'created' => Text::_('Fecha de alta'),
+                        'name' => Text::_('Nombre')
                     );
 
                     return new View(
@@ -2770,7 +2770,7 @@ namespace Goteo\Controller {
 
                 //el original tiene que ser de tpv o cash y estar como 'cargo ejecutado'
                 if ($original->method == 'paypal' || $original->status != 1) {
-                    Message::Error(_('No se puede reubicar este aporte!'));
+                    Message::Error(Text::_('No se puede reubicar este aporte!'));
                     throw new Redirection('/admin/invests');
                 }
 
@@ -2822,7 +2822,7 @@ namespace Goteo\Controller {
                              * Evento Feed
                              */
                             $log = new Feed();
-                            $log->title = _('Aporte reubicado');
+                            $log->title = Text::_('Aporte reubicado');
                             $log->url = '/admin/invests';
                             $log->type = 'money';
                             $log_text = _("%s ha aportado %s al proyecto %s en nombre de %s");
@@ -2836,14 +2836,14 @@ namespace Goteo\Controller {
                             $log->add($errors);
                             unset($log);
 
-                            Message::Info(_('Aporte reubicado correctamente'));
+                            Message::Info(Text::_('Aporte reubicado correctamente'));
                             throw new Redirection('/admin/invests');
                         } else {
 							$msgi = _("A fallado al cambiar el estado del aporte original (%s)");
                             $errors[] = sprintf($msgi, $original->id);
                         }
                     } else{
-                        $errors[] = _('Ha fallado algo al reubicar el aporte');
+                        $errors[] = Text::_('Ha fallado algo al reubicar el aporte');
                     }
 
                 }
@@ -2903,7 +2903,7 @@ namespace Goteo\Controller {
                          * Evento Feed
                          */
                         $log = new Feed();
-                        $log->title = _('Aporte manual');
+                        $log->title = Text::_('Aporte manual');
                         $log->url = '/admin/invests';
                         $log->type = 'money';
                         $log_text = _("%s ha aportado %s al proyecto %s en nombre de %s");
@@ -2917,10 +2917,10 @@ namespace Goteo\Controller {
                         $log->add($errors);
                         unset($log);
                         
-                        Message::Info( _('Aporte manual creado correctamente') );
+                        Message::Info( Text::_('Aporte manual creado correctamente') );
                         throw new Redirection('/admin/invests');
                     } else{
-                        $errors[] = _('Ha fallado algo al crear el aporte manual');
+                        $errors[] = Text::_('Ha fallado algo al crear el aporte manual');
                     }
 
                 }
@@ -2968,10 +2968,10 @@ namespace Goteo\Controller {
                 $campaigns = Model\Invest::campaigns();
                 // extras
                 $types = array(
-                    'donative' => _('Solo los donativos'),
-                    'anonymous' => _('Solo los anónimos'),
-                    'manual' => _('Solo los manuales'),
-                    'campaign' => _('Solo los de Bolsa'),
+                    'donative' => Text::_('Solo los donativos'),
+                    'anonymous' => Text::_('Solo los anónimos'),
+                    'manual' => Text::_('Solo los manuales'),
+                    'campaign' => Text::_('Solo los de Bolsa'),
                 );
 
            }
@@ -2981,7 +2981,7 @@ namespace Goteo\Controller {
                 // estados de aporte
                 $project = Model\Project::get($id);
                 if (!$project instanceof Model\Project) {
-                    Message::Error(_('Instancia de proyecto no valida'));
+                    Message::Error(Text::_('Instancia de proyecto no valida'));
                     throw new Redirection('/admin/invests');
                 }
                 $invests = Model\Invest::getAll($id);
@@ -3015,7 +3015,7 @@ namespace Goteo\Controller {
             if ($action == 'cancel') {
 
                 if ($project->status > 3 && $project->status < 6) {
-                    $errors[] = _('No debería poderse cancelar un aporte cuando el proyecto ya está financiado. Si es imprescindible, hacerlo desde el panel de paypal o tpv');
+                    $errors[] = Text::_('No debería poderse cancelar un aporte cuando el proyecto ya está financiado. Si es imprescindible, hacerlo desde el panel de paypal o tpv');
                     break;
                 }
 
@@ -3023,16 +3023,16 @@ namespace Goteo\Controller {
                     case 'paypal':
                         $err = array();
                         if (Paypal::cancelPreapproval($invest, $err)) {
-                            $errors[] = _('Preaproval paypal cancelado.');
+                            $errors[] = Text::_('Preaproval paypal cancelado.');
                             $log_text = _("El admin %s ha cancelado aporte y preapproval de %s de %s mediante PayPal (id: %s) al proyecto %s del dia %s");
                         } else {
                             $txt_errors = implode('; ', $err);
-                            $errors[] = _('Fallo al cancelar el preapproval en paypal: ') . $txt_errors;
+                            $errors[] = Text::_('Fallo al cancelar el preapproval en paypal: ') . $txt_errors;
                             $log_text = _("El admin %s ha fallado al cancelar el aporte de %s de %s mediante PayPal (id: %s) al proyecto %s del dia %s. <br />Se han dado los siguientes errores: ").$txt_errors;
                             if ($invest->cancel()) {
-                                $errors[] = _('Aporte cancelado');
+                                $errors[] = Text::_('Aporte cancelado');
                             } else{
-                                $errors[] = _('Fallo al cancelar el aporte');
+                                $errors[] = Text::_('Fallo al cancelar el aporte');
                             }
                         }
                         break;
@@ -3040,21 +3040,21 @@ namespace Goteo\Controller {
                         $err = array();
                         if (Tpv::cancelPreapproval($invest, $err)) {
                             $txt_errors = implode('; ', $err);
-                            $errors[] = _('Aporte cancelado correctamente. ') . $txt_errors;
+                            $errors[] = Text::_('Aporte cancelado correctamente. ') . $txt_errors;
                             $log_text = _("El admin %s ha anulado el cargo tpv de %s de %s mediante TPV (id: %s) al proyecto %s del dia %s");
                         } else {
                             $txt_errors = implode('; ', $err);
-                            $errors[] = _('Fallo en la operación. ') . $txt_errors;
+                            $errors[] = Text::_('Fallo en la operación. ') . $txt_errors;
                             $log_text = _("El admin %s ha fallado al solicitar la cancelación del cargo tpv de %s de %s mediante TPV (id: %s) al proyecto %s del dia %s. <br />Se han dado los siguientes errores: $txt_errors");
                         }
                         break;
                     case 'cash':
                         if ($invest->cancel()) {
                             $log_text = _("El admin %s ha cancelado aporte manual de %s de %s (id: %s) al proyecto %s del dia %s");
-                            $errors[] = _('Aporte cancelado');
+                            $errors[] = Text::_('Aporte cancelado');
                         } else{
                             $log_text = _("El admin %s ha fallado al cancelar el aporte manual de %s de %s (id: %s) al proyecto %s del dia %s. ");
-                            $errors[] = _('Fallo al cancelar el aporte');
+                            $errors[] = Text::_('Fallo al cancelar el aporte');
                         }
                         break;
                 }
@@ -3063,7 +3063,7 @@ namespace Goteo\Controller {
                  * Evento Feed
                  */
                 $log = new Feed();
-                $log->title = _('Cargo cancelado (admin)');
+                $log->title = Text::_('Cargo cancelado (admin)');
                 $log->url = '/admin/invests';
                 $log->type = 'system';
                 $log_items = array(
@@ -3088,20 +3088,20 @@ namespace Goteo\Controller {
                         $projectAccount = Model\Project\Account::get($invest->project);
 
                         if (empty($projectAccount->paypal)) {
-                            $errors[] = _('El proyecto no tiene cuenta paypal!!, ponersela en la seccion Contrato del dashboard del autor');
+                            $errors[] = Text::_('El proyecto no tiene cuenta paypal!!, ponersela en la seccion Contrato del dashboard del autor');
                             $log_text = null;
                             // Erroraco!
                             /*
                              * Evento Feed
                              */
                             $log = new Feed();
-                            $log->title = _('proyecto sin cuenta paypal (admin)');
+                            $log->title = Text::_('proyecto sin cuenta paypal (admin)');
                             $log->url = '/admin/projects';
                             $log->type = 'project';
-                            $log_text = _('El proyecto %s aun no ha puesto su %s !!!');
+                            $log_text = Text::_('El proyecto %s aun no ha puesto su %s !!!');
                             $log_items = array(
                                 Feed::item('project', $project->name, $project->id),
-                                Feed::item('relevant', _('cuenta PayPal'))
+                                Feed::item('relevant', Text::_('cuenta PayPal'))
                             );
                             $log->html = \vsprintf($log_text, $log_items);
                             $log->add($errors);
@@ -3113,29 +3113,29 @@ namespace Goteo\Controller {
 
                         $invest->account = $projectAccount->paypal;
                         if (Paypal::pay($invest, $errors)) {
-                            $errors[] = _('Cargo paypal correcto');
+                            $errors[] = Text::_('Cargo paypal correcto');
                             $log_text = _("El admin %s ha ejecutado el cargo a %s por su aporte de %s mediante PayPal (id: %s) al proyecto %s del dia %s");
                             $invest->status = 1;
                         } else {
                             $txt_errors = implode('; ', $errors);
-                            $errors[] = _('Fallo al ejecutar cargo paypal: ') . $txt_errors;
+                            $errors[] = Text::_('Fallo al ejecutar cargo paypal: ') . $txt_errors;
                             $log_text = _("El admin %s ha fallado al ejecutar el cargo a %s por su aporte de %s mediante PayPal (id: %s) al proyecto %s del dia %s. <br />Se han dado los siguientes errores: $txt_errors");
                         }
                         break;
                     case 'tpv':
                         if (Tpv::pay($invest, $errors)) {
-                            $errors[] = _('Cargo sermepa correcto');
+                            $errors[] = Text::_('Cargo sermepa correcto');
                             $log_text = _("El admin %s ha ejecutado el cargo a %s por su aporte de %s mediante TPV (id: %s) al proyecto %s del dia %s");
                             $invest->status = 1;
                         } else {
                             $txt_errors = implode('; ', $errors);
-                            $errors[] = _('Fallo al ejecutar cargo sermepa: ') . $txt_errors;
+                            $errors[] = Text::_('Fallo al ejecutar cargo sermepa: ') . $txt_errors;
                             $log_text = _("El admin %s ha fallado al ejecutar el cargo a %s por su aporte de %s mediante TPV (id: %s) al proyecto %s del dia %s <br />Se han dado los siguientes errores: $txt_errors");
                         }
                         break;
                     case 'cash':
                         $invest->setStatus('1');
-                        $errors[] = _('Aporte al contado, nada que ejecutar.');
+                        $errors[] = Text::_('Aporte al contado, nada que ejecutar.');
                         $log_text = _("El admin %s ha dado por ejecutado el aporte manual a nombre de %s por la cantidad de %s (id: %s) al proyecto %s del dia %s");
                         $invest->status = 1;
                         break;
@@ -3146,7 +3146,7 @@ namespace Goteo\Controller {
                      * Evento Feed
                      */
                     $log = new Feed();
-                    $log->title = _('Cargo ejecutado (admin)');
+                    $log->title = Text::_('Cargo ejecutado (admin)');
                     $log->url = '/admin/invests';
                     $log->type = 'system';
                     $log_items = array(
@@ -3268,10 +3268,10 @@ namespace Goteo\Controller {
 
             // filtros de revisión de proyecto
             $review = array(
-                'collect' => _('Recaudado'),
-                'paypal'  => _('Rev. PayPal'),
-                'tpv'     => _('Rev. TPV'),
-                'online'  => _('Pagos Online')
+                'collect' => Text::_('Recaudado'),
+                'paypal'  => Text::_('Rev. PayPal'),
+                'tpv'     => Text::_('Rev. TPV'),
+                'online'  => Text::_('Pagos Online')
             );
 
 
@@ -3369,8 +3369,8 @@ namespace Goteo\Controller {
             }
 
             $status = array(
-                        'nok' => _('Pendiente'),
-                        'ok'  => _('Cumplido')
+                        'nok' => Text::_('Pendiente'),
+                        'ok'  => Text::_('Cumplido')
                         
                     );
             $icons = Model\Icon::getAll('social');
@@ -3403,18 +3403,18 @@ namespace Goteo\Controller {
 
             $blog = Model\Blog::get(\GOTEO_NODE, 'node');
             if (!$blog instanceof \Goteo\Model\Blog) {
-                $errors[] = _('No tiene espacio de blog, Contacte con nosotros');
+                $errors[] = Text::_('No tiene espacio de blog, Contacte con nosotros');
                 $action = 'list';
             } else {
                 if (!$blog->active) {
-                    $errors[] = _('Lo sentimos, el blog para este nodo esta desactivado');
+                    $errors[] = Text::_('Lo sentimos, el blog para este nodo esta desactivado');
                     $action = 'list';
                 }
             }
 
             // primero comprobar que tenemos blog
             if (!$blog instanceof Model\Blog) {
-                $errors[] = _('No se ha encontrado ningún blog para este nodo');
+                $errors[] = Text::_('No se ha encontrado ningún blog para este nodo');
                 $action = 'list';
             }
 
@@ -3479,10 +3479,10 @@ namespace Goteo\Controller {
                     /// este es el único save que se lanza desde un metodo process_
                     if ($post->save($errors)) {
                         if ($action == 'edit') {
-                            $success[] = _('La entrada se ha actualizado correctamente');
+                            $success[] = Text::_('La entrada se ha actualizado correctamente');
                             ////Text::get('dashboard-project-updates-saved');
                         } else {
-                            $success[] = _('Se ha añadido una nueva entrada');
+                            $success[] = Text::_('Se ha añadido una nueva entrada');
                             ////Text::get('dashboard-project-updates-inserted');
                             $id = $post->id;
                         }
@@ -3493,10 +3493,10 @@ namespace Goteo\Controller {
                              * Evento Feed
                              */
                             $log = new Feed();
-                            $log->title = _('nueva entrada blog Goteo (admin)');
+                            $log->title = Text::_('nueva entrada blog Goteo (admin)');
                             $log->url = '/admin/blog';
                             $log->type = 'admin';
-                            $log_text = _('El admin %s ha %s en el blog Goteo la entrada "%s"');
+                            $log_text = Text::_('El admin %s ha %s en el blog Goteo la entrada "%s"');
                             $log_items = array(
                                 Feed::item('user', $_SESSION['user']->name, $_SESSION['user']->id),
                                 Feed::item('relevant', 'Publicado'),
@@ -3522,7 +3522,7 @@ namespace Goteo\Controller {
                         }
 
                     } else {
-                        $errors[] = _('Ha habido algun problema al guardar los datos');
+                        $errors[] = Text::_('Ha habido algun problema al guardar los datos');
                         ////Text::get('dashboard-project-updates-fail');
                     }
             }
@@ -3545,13 +3545,13 @@ namespace Goteo\Controller {
                          * Evento Feed
                          */
                         $log = new Feed();
-                        $log->title = _('entrada quitada (admin)');
+                        $log->title = Text::_('entrada quitada (admin)');
                         $log->url = '/admin/blog';
                         $log->type = 'admin';
-                        $log_text = _('El admin %s ha %s la entrada "%s" del blog de Goteo');
+                        $log_text = Text::_('El admin %s ha %s la entrada "%s" del blog de Goteo');
                         $log_items = array(
                             Feed::item('user', $_SESSION['user']->name, $_SESSION['user']->id),
-                            Feed::item('relevant', _('Quitado')),
+                            Feed::item('relevant', Text::_('Quitado')),
                             Feed::item('blog', $tempData->title)
                         );
                         $log->html = \vsprintf($log_text, $log_items);
@@ -3560,9 +3560,9 @@ namespace Goteo\Controller {
                         unset($log);
 
                         unset($blog->posts[$id]);
-                        $success[] = _('Entrada eliminada');
+                        $success[] = Text::_('Entrada eliminada');
                     } else {
-                        $errors[] = _('No se ha podido eliminar la entrada');
+                        $errors[] = Text::_('No se ha podido eliminar la entrada');
                     }
                     // no break para que continue con list
                 case 'list':
@@ -3594,7 +3594,7 @@ namespace Goteo\Controller {
                             )
                         );
 
-                    $message = _('Añadiendo una nueva entrada');
+                    $message = Text::_('Añadiendo una nueva entrada');
 
                     return new View(
                         'view/admin/index.html.php',
@@ -3621,14 +3621,14 @@ namespace Goteo\Controller {
                         $post = Model\Blog\Post::get($id);
 
                         if (!$post instanceof Model\Blog\Post) {
-                            $errors[] = _('La entrada esta corrupta, contacte con nosotros.');
+                            $errors[] = Text::_('La entrada esta corrupta, contacte con nosotros.');
                             //Text::get('dashboard-project-updates-postcorrupt');
                             $action = 'list';
                             break;
                         }
                     }
 
-                    $message = _('Editando una entrada existente');
+                    $message = Text::_('Editando una entrada existente');
 
                     return new View(
                         'view/admin/index.html.php',
@@ -3704,14 +3704,14 @@ namespace Goteo\Controller {
                     /// este es el único save que se lanza desde un metodo process_
                     if ($post->save($errors)) {
                         if ($action == 'edit') {
-                            $success[] = _('El término se ha actualizado correctamente');
+                            $success[] = Text::_('El término se ha actualizado correctamente');
                         } else {
-                            $success[] = _('Se ha añadido un nuevo término');
+                            $success[] = Text::_('Se ha añadido un nuevo término');
                             $id = $post->id;
                         }
                         $action = $editing ? 'edit' : 'list';
                     } else {
-                        $errors[] = _('Ha habido algun problema al guardar los datos');
+                        $errors[] = Text::_('Ha habido algun problema al guardar los datos');
                     }
             }
 
@@ -3728,9 +3728,9 @@ namespace Goteo\Controller {
                 case 'remove':
                     // eliminar un término
                     if (Model\Glossary::delete($id)) {
-                        $success[] = _('Término eliminado');
+                        $success[] = Text::_('Término eliminado');
                     } else {
-                        $errors[] = _('No se ha podido eliminar el término');
+                        $errors[] = Text::_('No se ha podido eliminar el término');
                     }
                     break;
                 case 'add':
@@ -3738,7 +3738,7 @@ namespace Goteo\Controller {
                     // obtenemos datos basicos
                     $post = new Model\Glossary();
 
-                    $message = _('Añadiendo un nuevo término');
+                    $message = Text::_('Añadiendo un nuevo término');
 
                     return new View(
                         'view/admin/index.html.php',
@@ -3761,14 +3761,14 @@ namespace Goteo\Controller {
                         $post = Model\Glossary::get($id);
 
                         if (!$post instanceof Model\Glossary) {
-                            $errors[] = _('La entrada esta corrupta, contacte con nosotros.');
+                            $errors[] = Text::_('La entrada esta corrupta, contacte con nosotros.');
                             //Text::get('dashboard-project-updates-postcorrupt');
                             $action = 'list';
                             break;
                         }
                     }
 
-                    $message = _('Editando un término existente');
+                    $message = Text::_('Editando un término existente');
 
                     return new View(
                         'view/admin/index.html.php',
@@ -3860,18 +3860,18 @@ namespace Goteo\Controller {
                     /// este es el único save que se lanza desde un metodo process_
                     if ($post->save($errors)) {
                         if ($action == 'edit') {
-                            $success[] = _('La entrada se ha actualizado correctamente');
+                            $success[] = Text::_('La entrada se ha actualizado correctamente');
 
                             if ((bool) $post->publish) {
-                                $log_action = _('Publicado');
+                                $log_action = Text::_('Publicado');
                             } else {
-                                $log_action = _('Modificado');
+                                $log_action = Text::_('Modificado');
                             }
 
                         } else {
-                            $success[] = _('Se ha añadido una nueva entrada');
+                            $success[] = Text::_('Se ha añadido una nueva entrada');
                             $id = $post->id;
-                            $log_action = _('Añadido');
+                            $log_action = Text::_('Añadido');
                         }
                         $action = $editing ? 'edit' : 'list';
 
@@ -3879,10 +3879,10 @@ namespace Goteo\Controller {
                          * Evento Feed
                          */
                         $log = new Feed();
-                        $log->title = _('modificacion de idea about (admin)');
+                        $log->title = Text::_('modificacion de idea about (admin)');
                         $log->url = '/admin/info';
                         $log->type = 'admin';
-                        $log_text = _('El admin %s ha %s la Idea de fuerza "%s"');
+                        $log_text = Text::_('El admin %s ha %s la Idea de fuerza "%s"');
                         $log_items = array(
                             Feed::item('user', $_SESSION['user']->name, $_SESSION['user']->id),
                             Feed::item('relevant', $log_action),
@@ -3893,7 +3893,7 @@ namespace Goteo\Controller {
                         unset($log);
 
                     } else {
-                        $errors[] = _('Ha habido algun problema al guardar los datos');
+                        $errors[] = Text::_('Ha habido algun problema al guardar los datos');
                     }
             }
 
@@ -3917,19 +3917,19 @@ namespace Goteo\Controller {
                     $tempData = Model\Info::get($id);
                     // eliminar un término
                     if (Model\Info::delete($id)) {
-                        $success[] = _('Entrada eliminada');
+                        $success[] = Text::_('Entrada eliminada');
 
                         /*
                          * Evento Feed
                          */
                         $log = new Feed();
-                        $log->title = _('quitar de idea about (admin)');
+                        $log->title = Text::_('quitar de idea about (admin)');
                         $log->url = '/admin/info';
                         $log->type = 'admin';
-                        $log_text = _('El admin %s ha %s la Idea de fuerza "%s"');
+                        $log_text = Text::_('El admin %s ha %s la Idea de fuerza "%s"');
                         $log_items = array(
                             Feed::item('user', $_SESSION['user']->name, $_SESSION['user']->id),
-                            Feed::item('relevant', _('Eliminado')),
+                            Feed::item('relevant', Text::_('Eliminado')),
                             Feed::item('relevant', $tempData->title)
                         );
                         $log->html = \vsprintf($log_text, $log_items);
@@ -3937,7 +3937,7 @@ namespace Goteo\Controller {
                         unset($log);
 
                     } else {
-                        $errors[] = _('No se ha podido eliminar la entrada');
+                        $errors[] = Text::_('No se ha podido eliminar la entrada');
                     }
                     break;
                 case 'add':
@@ -3947,7 +3947,7 @@ namespace Goteo\Controller {
                         $post = new Model\Info();
                     }
 
-                    $message = _('Añadiendo una nueva entrada');
+                    $message = Text::_('Añadiendo una nueva entrada');
 
                     return new View(
                         'view/admin/index.html.php',
@@ -3970,14 +3970,14 @@ namespace Goteo\Controller {
                         $post = Model\Info::get($id);
 
                         if (!$post instanceof Model\Info) {
-                            $errors[] = _('La entrada esta corrupta, contacte con nosotros.');
+                            $errors[] = Text::_('La entrada esta corrupta, contacte con nosotros.');
                             //Text::get('dashboard-project-updates-postcorrupt');
                             $action = 'list';
                             break;
                         }
                     }
 
-                    $message = _('Editando una entrada existente');
+                    $message = Text::_('Editando una entrada existente');
 
                     return new View(
                         'view/admin/index.html.php',
@@ -4042,7 +4042,7 @@ namespace Goteo\Controller {
                                 'action' => "$url/edit/",
                                 'submit' => array(
                                     'name' => 'update',
-                                    'label' => _('Añadir')
+                                    'label' => Text::_('Añadir')
                                 ),
                                 'fields' => array (
                                     'id' => array(
@@ -4052,25 +4052,25 @@ namespace Goteo\Controller {
 
                                     ),
                                     'title' => array(
-                                        'label' => _('Noticia'),
+                                        'label' => Text::_('Noticia'),
                                         'name' => 'title',
                                         'type' => 'text',
                                         'properties' => 'size="100" maxlength="100"'
                                     ),
                                     'description' => array(
-                                        'label' => _('Entradilla'),
+                                        'label' => Text::_('Entradilla'),
                                         'name' => 'description',
                                         'type' => 'textarea',
                                         'properties' => 'cols="100" rows="2"'
                                     ),
                                     'url' => array(
-                                        'label' => _('Enlace'),
+                                        'label' => Text::_('Enlace'),
                                         'name' => 'url',
                                         'type' => 'text',
                                         'properties' => 'size=100'
                                     ),
                                     'order' => array(
-                                        'label' => _('Posición'),
+                                        'label' => Text::_('Posición'),
                                         'name' => 'order',
                                         'type' => 'text'
                                     )
@@ -4104,13 +4104,13 @@ namespace Goteo\Controller {
                                  * Evento Feed
                                  */
                                 $log = new Feed();
-                                $log->title = _('nueva micronoticia (admin)');
+                                $log->title = Text::_('nueva micronoticia (admin)');
                                 $log->url = '/admin/news';
                                 $log->type = 'admin';
-                                $log_text = _('El admin %s ha %s la micronoticia "%s"');
+                                $log_text = Text::_('El admin %s ha %s la micronoticia "%s"');
                                 $log_items = array(
                                     Feed::item('user', $_SESSION['user']->name, $_SESSION['user']->id),
-                                    Feed::item('relevant', _('Publicado')),
+                                    Feed::item('relevant', Text::_('Publicado')),
                                     Feed::item('news', $_POST['title'], '#news'.$item->id)
                                 );
                                 $log->html = \vsprintf($log_text, $log_items);
@@ -4145,25 +4145,25 @@ namespace Goteo\Controller {
 
                                     ),
                                     'title' => array(
-                                        'label' => _('Noticia'),
+                                        'label' => Text::_('Noticia'),
                                         'name' => 'title',
                                         'type' => 'text',
                                         'properties' => 'size="100"  maxlength="80"'
                                     ),
                                     'description' => array(
-                                        'label' => _('Entradilla'),
+                                        'label' => Text::_('Entradilla'),
                                         'name' => 'description',
                                         'type' => 'textarea',
                                         'properties' => 'cols="100" rows="2"'
                                     ),
                                     'url' => array(
-                                        'label' => _('Enlace'),
+                                        'label' => Text::_('Enlace'),
                                         'name' => 'url',
                                         'type' => 'text',
                                         'properties' => 'size=100'
                                     ),
                                     'order' => array(
-                                        'label' => _('Posición'),
+                                        'label' => Text::_('Posición'),
                                         'name' => 'order',
                                         'type' => 'text'
                                     )
@@ -4188,10 +4188,10 @@ namespace Goteo\Controller {
                          * Evento Feed
                          */
                         $log = new Feed();
-                        $log->title = _('micronoticia quitada (admin)');
+                        $log->title = Text::_('micronoticia quitada (admin)');
                         $log->url = '/admin/news';
                         $log->type = 'admin';
-                        $log_text = _('El admin %s ha %s la micronoticia "%s"');
+                        $log_text = Text::_('El admin %s ha %s la micronoticia "%s"');
                         $log_items = array(
                             Feed::item('user', $_SESSION['user']->name, $_SESSION['user']->id),
                             Feed::item('relevant', 'Quitado'),
@@ -4213,13 +4213,13 @@ namespace Goteo\Controller {
                     'folder' => 'base',
                     'file' => 'list',
                     'model' => 'news',
-                    'addbutton' => _('Nueva noticia'),
+                    'addbutton' => Text::_('Nueva noticia'),
                     'data' => $model::getAll(),
                     'columns' => array(
                         'edit' => '',
-                        'title' => _('Noticia'),
-                        'url' => _('Enlace'),
-                        'order' => _('Posición'),
+                        'title' => Text::_('Noticia'),
+                        'url' => Text::_('Enlace'),
+                        'order' => Text::_('Posición'),
                         'up' => '',
                         'down' => '',
                         'translate' => '',
@@ -4262,33 +4262,33 @@ namespace Goteo\Controller {
                                 'action' => "$url/edit/",
                                 'submit' => array(
                                     'name' => 'update',
-                                    'label' => _('Añadir')
+                                    'label' => Text::_('Añadir')
                                 ),
                                 'fields' => array (
                                     'id' => array(
-                                        'label' => _(''),
+                                        'label' => Text::_(''),
                                         'name' => 'id',
                                         'type' => 'hidden'
 
                                     ),
                                     'name' => array(
-                                        'label' => _('Patrocinador'),
+                                        'label' => Text::_('Patrocinador'),
                                         'name' => 'name',
                                         'type' => 'text'
                                     ),
                                     'url' => array(
-                                        'label' => _('Enlace'),
+                                        'label' => Text::_('Enlace'),
                                         'name' => 'url',
                                         'type' => 'text',
                                         'properties' => 'size=100'
                                     ),
                                     'image' => array(
-                                        'label' => _('Logo'),
+                                        'label' => Text::_('Logo'),
                                         'name' => 'image',
                                         'type' => 'image'
                                     ),
                                     'order' => array(
-                                        'label' => _('Posición'),
+                                        'label' => Text::_('Posición'),
                                         'name' => 'order',
                                         'type' => 'text'
                                     )
@@ -4349,29 +4349,29 @@ namespace Goteo\Controller {
                                 ),
                                 'fields' => array (
                                     'id' => array(
-                                        'label' => _(''),
+                                        'label' => Text::_(''),
                                         'name' => 'id',
                                         'type' => 'hidden'
 
                                     ),
                                     'name' => array(
-                                        'label' => _('Patrocinador'),
+                                        'label' => Text::_('Patrocinador'),
                                         'name' => 'name',
                                         'type' => 'text'
                                     ),
                                     'url' => array(
-                                        'label' => _('Enlace'),
+                                        'label' => Text::_('Enlace'),
                                         'name' => 'url',
                                         'type' => 'text',
                                         'properties' => 'size=100'
                                     ),
                                     'image' => array(
-                                        'label' => _('Logo'),
+                                        'label' => Text::_('Logo'),
                                         'name' => 'image',
                                         'type' => 'image'
                                     ),
                                     'order' => array(
-                                        'label' => _('Posición'),
+                                        'label' => Text::_('Posición'),
                                         'name' => 'order',
                                         'type' => 'text'
                                     )
@@ -4401,14 +4401,14 @@ namespace Goteo\Controller {
                 array(
                     'folder' => 'base',
                     'file' => 'list',
-                    'addbutton' => _('Nuevo patrocinador'),
+                    'addbutton' => Text::_('Nuevo patrocinador'),
                     'data' => $model::getAll(),
                     'columns' => array(
                         'edit' => '',
-                        'name' => _('Patrocinador'),
-                        'url' => _('Enlace'),
-                        'image' => _('Imagen'),
-                        'order' => _('Posición'),
+                        'name' => Text::_('Patrocinador'),
+                        'url' => Text::_('Enlace'),
+                        'image' => Text::_('Imagen'),
+                        'order' => Text::_('Posición'),
                         'up' => '',
                         'down' => '',
                         'remove' => ''
@@ -4450,22 +4450,22 @@ namespace Goteo\Controller {
                                 'action' => "$url/edit/",
                                 'submit' => array(
                                     'name' => 'update',
-                                    'label' => _('Añadir')
+                                    'label' => Text::_('Añadir')
                                 ),
                                 'fields' => array (
                                     'id' => array(
-                                        'label' => _(''),
+                                        'label' => Text::_(''),
                                         'name' => 'id',
                                         'type' => 'hidden'
 
                                     ),
                                     'name' => array(
-                                        'label' => _('Campaña'),
+                                        'label' => Text::_('Campaña'),
                                         'name' => 'name',
                                         'type' => 'text'
                                     ),
                                     'description' => array(
-                                        'label' => _('Descripción'),
+                                        'label' => Text::_('Descripción'),
                                         'name' => 'description',
                                         'type' => 'textarea',
                                         'properties' => 'cols="100" rows="2"'
@@ -4512,18 +4512,18 @@ namespace Goteo\Controller {
                                 ),
                                 'fields' => array (
                                     'id' => array(
-                                        'label' => _(''),
+                                        'label' => Text::_(''),
                                         'name' => 'id',
                                         'type' => 'hidden'
 
                                     ),
                                     'name' => array(
-                                        'label' => _('Campaña'),
+                                        'label' => Text::_('Campaña'),
                                         'name' => 'name',
                                         'type' => 'text'
                                     ),
                                     'description' => array(
-                                        'label' => _('Descripción'),
+                                        'label' => Text::_('Descripción'),
                                         'name' => 'description',
                                         'type' => 'textarea',
                                         'properties' => 'cols="100" rows="2"'
@@ -4548,12 +4548,12 @@ namespace Goteo\Controller {
                 array(
                     'folder' => 'base',
                     'file' => 'list',
-                    'addbutton' => _('Nueva campaña'),
+                    'addbutton' => Text::_('Nueva campaña'),
                     'data' => $model::getList(),
                     'columns' => array(
                         'edit' => '',
-                        'name' => _('Campaña'),
-                        'used' => _('Aportes'),
+                        'name' => Text::_('Campaña'),
+                        'used' => Text::_('Aportes'),
                         'remove' => ''
                     ),
                     'url' => "$url",
@@ -4593,22 +4593,22 @@ namespace Goteo\Controller {
                                 'action' => "$url/edit/",
                                 'submit' => array(
                                     'name' => 'update',
-                                    'label' => _('Añadir')
+                                    'label' => Text::_('Añadir')
                                 ),
                                 'fields' => array (
                                     'id' => array(
-                                        'label' => _(''),
+                                        'label' => Text::_(''),
                                         'name' => 'id',
                                         'type' => 'hidden'
 
                                     ),
                                     'name' => array(
-                                        'label' => _('Campaña'),
+                                        'label' => Text::_('Campaña'),
                                         'name' => 'name',
                                         'type' => 'text'
                                     ),
                                     'description' => array(
-                                        'label' => _('Descripción'),
+                                        'label' => Text::_('Descripción'),
                                         'name' => 'description',
                                         'type' => 'textarea',
                                         'properties' => 'cols="100" rows="2"'
@@ -4655,18 +4655,18 @@ namespace Goteo\Controller {
                                 ),
                                 'fields' => array (
                                     'id' => array(
-                                        'label' => _(''),
+                                        'label' => Text::_(''),
                                         'name' => 'id',
                                         'type' => 'hidden'
 
                                     ),
                                     'name' => array(
-                                        'label' => _('Campaña'),
+                                        'label' => Text::_('Campaña'),
                                         'name' => 'name',
                                         'type' => 'text'
                                     ),
                                     'description' => array(
-                                        'label' => _('Descripción'),
+                                        'label' => Text::_('Descripción'),
                                         'name' => 'description',
                                         'type' => 'textarea',
                                         'properties' => 'cols="100" rows="2"'
@@ -4691,12 +4691,12 @@ namespace Goteo\Controller {
                 array(
                     'folder' => 'base',
                     'file' => 'list',
-                    'addbutton' => _('Nuevo nodo'),
+                    'addbutton' => Text::_('Nuevo nodo'),
                     'data' => $model::getList(),
                     'columns' => array(
                         'edit' => '',
-                        'name' => _('Campaña'),
-                        'used' => _('Aportes'),
+                        'name' => Text::_('Campaña'),
+                        'used' => Text::_('Aportes'),
                         'remove' => ''
                     ),
                     'url' => "$url",
@@ -4728,14 +4728,14 @@ namespace Goteo\Controller {
             $status = Model\Project::status();
             $methods = Model\Invest::methods();
             $types = array(
-                'investor' => _('Cofinanciadores'),
-                'owner' => _('Autores'),
-                'user' => _('Usuarios')
+                'investor' => Text::_('Cofinanciadores'),
+                'owner' => Text::_('Autores'),
+                'user' => Text::_('Usuarios')
             );
             $roles = array(
-                'admin' => _('Administrador'),
-                'checker' => _('Revisor'),
-                'translator' => _('Traductor')
+                'admin' => Text::_('Administrador'),
+                'checker' => Text::_('Revisor'),
+                'translator' => Text::_('Traductor')
             );
 
             // una variable de sesion para mantener los datos de todo esto
@@ -4802,26 +4802,26 @@ namespace Goteo\Controller {
                         if (!empty($filters['project']) && !empty($sqlInner)) {
                             $sqlFilter .= " AND project.name LIKE (:project) ";
                             $values[':project'] = '%'.$filters['project'].'%';
-                            $_SESSION['mailing']['filters_txt'] .= _('de proyectos que su nombre contenga').' <strong>\'' . $filters['project'] . '\'</strong> ';
+                            $_SESSION['mailing']['filters_txt'] .= Text::_('de proyectos que su nombre contenga').' <strong>\'' . $filters['project'] . '\'</strong> ';
                         } elseif (empty($filters['project']) && !empty($sqlInner)) {
-                            $_SESSION['mailing']['filters_txt'] .= _('de cualquier proyecto');
+                            $_SESSION['mailing']['filters_txt'] .= Text::_('de cualquier proyecto');
                         }
 
                         if (isset($filters['status']) && $filters['status'] > -1 && !empty($sqlInner)) {
                             $sqlFilter .= "AND project.status = :status ";
                             $values[':status'] = $filters['status'];
-                            $_SESSION['mailing']['filters_txt'] .= _('en estado').' <strong>' . $status[$filters['status']] . '</strong> ';
+                            $_SESSION['mailing']['filters_txt'] .= Text::_('en estado').' <strong>' . $status[$filters['status']] . '</strong> ';
                         } elseif ($filters['status'] < 0 && !empty($sqlInner)) {
-                            $_SESSION['mailing']['filters_txt'] .= _('en cualquier estado');
+                            $_SESSION['mailing']['filters_txt'] .= Text::_('en cualquier estado');
                         }
 
                         if ($filters['type'] == 'investor') {
                             if (!empty($filters['method']) && !empty($sqlInner)) {
                                 $sqlFilter .= "AND invest.method = :method ";
                                 $values[':method'] = $filters['method'];
-                                $_SESSION['mailing']['filters_txt'] .= _('mediante').' <strong>' . $methods[$filters['method']] . '</strong> ';
+                                $_SESSION['mailing']['filters_txt'] .= Text::_('mediante').' <strong>' . $methods[$filters['method']] . '</strong> ';
                             } elseif (empty($filters['method']) && !empty($sqlInner)) {
-                                $_SESSION['mailing']['filters_txt'] .= _('mediante cualquier metodo');
+                                $_SESSION['mailing']['filters_txt'] .= Text::_('mediante cualquier metodo');
                             }
                         }
 
@@ -4831,7 +4831,7 @@ namespace Goteo\Controller {
                                     AND user_interest.interest = :interest
                                     ";
                             $values[':interest'] = $filters['interest'];
-                            $_SESSION['mailing']['filters_txt'] .= _('interesados en fin').' <strong>' . $interests[$filters['interest']] . '</strong> ';
+                            $_SESSION['mailing']['filters_txt'] .= Text::_('interesados en fin').' <strong>' . $interests[$filters['interest']] . '</strong> ';
                         }
 
                         if (!empty($filters['role'])) {
@@ -4840,18 +4840,18 @@ namespace Goteo\Controller {
                                     AND user_role.role_id = :role
                                     ";
                             $values[':role'] = $filters['role'];
-                            $_SESSION['mailing']['filters_txt'] .= _('que sean').' <strong>' . $roles[$filters['role']] . '</strong> ';
+                            $_SESSION['mailing']['filters_txt'] .= Text::_('que sean').' <strong>' . $roles[$filters['role']] . '</strong> ';
                         }
 
                         if (!empty($filters['name'])) {
                             $sqlFilter .= " AND ( user.name LIKE (:name) OR user.email LIKE (:name) ) ";
                             $values[':name'] = '%'.$filters['name'].'%';
-                            $_SESSION['mailing']['filters_txt'] .= _('que su nombre o email contenga').' <strong>\'' . $filters['name'] . '\'</strong> ';
+                            $_SESSION['mailing']['filters_txt'] .= Text::_('que su nombre o email contenga').' <strong>\'' . $filters['name'] . '\'</strong> ';
                         }
 
                         if (!empty($filters['workshopper'])) {
                             $sqlFilter .= " AND user.password = SHA1(user.email) ";
-                            $_SESSION['mailing']['filters_txt'] .= _('que su contraseña sea igual que su email');
+                            $_SESSION['mailing']['filters_txt'] .= Text::_('que su contraseña sea igual que su email');
                         }
 
                         $sql = "SELECT
@@ -4875,12 +4875,12 @@ namespace Goteo\Controller {
                                 $_SESSION['mailing']['receivers'][$receiver->id] = $receiver;
                             }
                         } else {
-                            $_SESSION['mailing']['errors'][] = _('Fallo el SQL!!!!!').' <br />' . $sql . '<pre>'.print_r($values, 1).'</pre>';
+                            $_SESSION['mailing']['errors'][] = Text::_('Fallo el SQL!!!!!').' <br />' . $sql . '<pre>'.print_r($values, 1).'</pre>';
                         }
 
                         // si no hay destinatarios, salta a la lista con mensaje de error
                         if (empty($_SESSION['mailing']['receivers'])) {
-                            $_SESSION['mailing']['errors'][] = _('No se han encontrado destinatarios para ') . $_SESSION['mailing']['filters_txt'];
+                            $_SESSION['mailing']['errors'][] = Text::_('No se han encontrado destinatarios para ') . $_SESSION['mailing']['filters_txt'];
 
                             throw new Redirection('/admin/mailing/list');
                         }
@@ -5075,19 +5075,19 @@ namespace Goteo\Controller {
 
 				if (Worth::save($data, $errors)) {
                     $action = 'list';
-                    $success[] = _('Nivel de meritocracia modificado');
+                    $success[] = Text::_('Nivel de meritocracia modificado');
 
                     /*
                      * Evento Feed
                      */
                     $log = new Feed();
-                    $log->title = _('modificacion de meritocracia (admin)');
+                    $log->title = Text::_('modificacion de meritocracia (admin)');
                     $log->url = '/admin/worth';
                     $log->type = 'admin';
                     $log_text = _("El admin %s ha %s el nivel de meritocrácia %s");
                     $log_items = array(
                         Feed::item('user', $_SESSION['user']->name, $_SESSION['user']->id),
-                        Feed::item('relevant', _('Modificado')),
+                        Feed::item('relevant', Text::_('Modificado')),
                         Feed::item('project', $icon->name)
                     );
                     $log->html = \vsprintf($log_text, $log_items);
@@ -5177,185 +5177,185 @@ namespace Goteo\Controller {
 
             $menu = array(
                 'contents' => array(
-                    'label'   => _('Gestión de Textos y Traducciones'),
+                    'label'   => Text::_('Gestión de Textos y Traducciones'),
                     'options' => array (
                         'blog' => array(
-                            'label' => _('Blog'),
+                            'label' => Text::_('Blog'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'add'  => array('label' => _('Nueva Entrada'), 'item' => false),
-                                'edit' => array('label' => _('Editando Entrada'), 'item' => true),
-                                'translate' => array('label' => _('Traduciendo Entrada'), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'add'  => array('label' => Text::_('Nueva Entrada'), 'item' => false),
+                                'edit' => array('label' => Text::_('Editando Entrada'), 'item' => true),
+                                'translate' => array('label' => Text::_('Traduciendo Entrada'), 'item' => true)
                             )
                         ),
                         'texts' => array(
-                            'label' => _('Textos interficie'),
+                            'label' => Text::_('Textos interficie'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'edit' => array('label' => _('Editando Original'), 'item' => true),
-                                'translate' => array('label' => _('Traduciendo Texto'), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'edit' => array('label' => Text::_('Editando Original'), 'item' => true),
+                                'translate' => array('label' => Text::_('Traduciendo Texto'), 'item' => true)
                             )
                         ),
                         'faq' => array(
-                            'label' => _('FAQs'),
+                            'label' => Text::_('FAQs'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'add'  => array('label' => _('Nueva Pregunta'), 'item' => false),
-                                'edit' => array('label' => _('Editando Pregunta'), 'item' => true),
-                                'translate' => array('label' => _('Traduciendo Pregunta'), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'add'  => array('label' => Text::_('Nueva Pregunta'), 'item' => false),
+                                'edit' => array('label' => Text::_('Editando Pregunta'), 'item' => true),
+                                'translate' => array('label' => Text::_('Traduciendo Pregunta'), 'item' => true)
                             )
                         ),
                         'pages' => array(
-                            'label' => _('Páginas institucionales'),
+                            'label' => Text::_('Páginas institucionales'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'edit' => array('label' => _('Editando Página'), 'item' => true),
-                                'translate' => array('label' => _('Traduciendo Página'), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'edit' => array('label' => Text::_('Editando Página'), 'item' => true),
+                                'translate' => array('label' => Text::_('Traduciendo Página'), 'item' => true)
                             )
                         ),
                         'categories' => array(
-                            'label' => _('Categorias e Intereses'),
+                            'label' => Text::_('Categorias e Intereses'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'add'  => array('label' => _('Nueva Categoría'), 'item' => false),
-                                'edit' => array('label' => _('Editando Categoría'), 'item' => true),
-                                'translate' => array('label' => _('Traduciendo Categoría'), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'add'  => array('label' => Text::_('Nueva Categoría'), 'item' => false),
+                                'edit' => array('label' => Text::_('Editando Categoría'), 'item' => true),
+                                'translate' => array('label' => Text::_('Traduciendo Categoría'), 'item' => true)
                             )
                         ),
                         'licenses' => array(
-                            'label' => _('Licencias'),
+                            'label' => Text::_('Licencias'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'edit' => array('label' => _('Editando Licencia'), 'item' => true),
-                                'translate' => array('label' => _('Traduciendo Licencia'), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'edit' => array('label' => Text::_('Editando Licencia'), 'item' => true),
+                                'translate' => array('label' => Text::_('Traduciendo Licencia'), 'item' => true)
                             )
                         ),
                         'icons' => array(
-                            'label' => _('Tipos de Retorno'),
+                            'label' => Text::_('Tipos de Retorno'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'edit' => array('label' => _('Editando Tipo'), 'item' => true),
-                                'translate' => array('label' => _('Traduciendo Tipo'), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'edit' => array('label' => Text::_('Editando Tipo'), 'item' => true),
+                                'translate' => array('label' => Text::_('Traduciendo Tipo'), 'item' => true)
                             )
                         ),
                         'tags' => array(
-                            'label' => _('Tags de blog'),
+                            'label' => Text::_('Tags de blog'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'add'  => array('label' => _('Nuevo Tag'), 'item' => false),
-                                'edit' => array('label' => _('Editando Tag'), 'item' => true),
-                                'translate' => array('label' => _('Traduciendo Tag'), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'add'  => array('label' => Text::_('Nuevo Tag'), 'item' => false),
+                                'edit' => array('label' => Text::_('Editando Tag'), 'item' => true),
+                                'translate' => array('label' => Text::_('Traduciendo Tag'), 'item' => true)
                             )
                         ),
                         'criteria' => array(
-                            'label' => _('Criterios de revisión'),
+                            'label' => Text::_('Criterios de revisión'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'add'  => array('label' => _('Nuevo Criterio'), 'item' => false),
-                                'edit' => array('label' => _('Editando Criterio'), 'item' => true),
-                                'translate' => array('label' => _('Traduciendo Criterio'), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'add'  => array('label' => Text::_('Nuevo Criterio'), 'item' => false),
+                                'edit' => array('label' => Text::_('Editando Criterio'), 'item' => true),
+                                'translate' => array('label' => Text::_('Traduciendo Criterio'), 'item' => true)
                             )
                         ),
                         'templates' => array(
-                            'label' => _('Plantillas de email'),
+                            'label' => Text::_('Plantillas de email'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'edit' => array('label' => _('Editando Plantilla'), 'item' => true),
-                                'translate' => array('label' => _('Traduciendo Plantilla'), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'edit' => array('label' => Text::_('Editando Plantilla'), 'item' => true),
+                                'translate' => array('label' => Text::_('Traduciendo Plantilla'), 'item' => true)
                             )
                         ),
                         'glossary' => array(
-                            'label' => _('Glosario'),
+                            'label' => Text::_('Glosario'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'edit' => array('label' => _('Editando Término'), 'item' => true),
-                                'translate' => array('label' => _('Traduciendo Término'), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'edit' => array('label' => Text::_('Editando Término'), 'item' => true),
+                                'translate' => array('label' => Text::_('Traduciendo Término'), 'item' => true)
                             )
                         ),
                         'info' => array(
-                            'label' => _('Ideas about'),
+                            'label' => Text::_('Ideas about'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'edit' => array('label' => _('Editando Idea'), 'item' => true),
-                                'translate' => array('label' => _('Traduciendo Idea'), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'edit' => array('label' => Text::_('Editando Idea'), 'item' => true),
+                                'translate' => array('label' => Text::_('Traduciendo Idea'), 'item' => true)
                             )
                         ),
                         'wordcount' => array(
-                            'label' => _('Conteo de palabras'),
+                            'label' => Text::_('Conteo de palabras'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false)
                             )
                         )
                     )
                 ),
                 'projects' => array(
-                    'label'   => _('Gestión de proyectos'),
+                    'label'   => Text::_('Gestión de proyectos'),
                     'options' => array (
                         'projects' => array(
-                            'label' => _('Listado de proyectos'),
+                            'label' => Text::_('Listado de proyectos'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'dates' => array('label' => _('Cambiando las fechas del proyecto '), 'item' => true),
-                                'accounts' => array('label' => _('Gestionando las cuentas del proyecto '), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'dates' => array('label' => Text::_('Cambiando las fechas del proyecto '), 'item' => true),
+                                'accounts' => array('label' => Text::_('Gestionando las cuentas del proyecto '), 'item' => true)
                             )
                         ),
                         'reviews' => array(
-                            'label' => _('Revisiones'),
+                            'label' => Text::_('Revisiones'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'add'  => array('label' => _('Iniciando briefing'), 'item' => false),
-                                'edit' => array('label' => _('Editando briefing'), 'item' => true),
-                                'report' => array('label' => _('Informe'), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'add'  => array('label' => Text::_('Iniciando briefing'), 'item' => false),
+                                'edit' => array('label' => Text::_('Editando briefing'), 'item' => true),
+                                'report' => array('label' => Text::_('Informe'), 'item' => true)
                             )
                         ),
                         'translates' => array(
-                            'label' => _('Traducciones'),
+                            'label' => Text::_('Traducciones'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'add'  => array('label' => _('Habilitando traducción'), 'item' => false),
-                                'edit' => array('label' => _('Asignando traducción'), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'add'  => array('label' => Text::_('Habilitando traducción'), 'item' => false),
+                                'edit' => array('label' => Text::_('Asignando traducción'), 'item' => true)
                             )
                         ),
                         'rewards' => array(
-                            'label' => _('Gestión de retornos colectivos cumplidos'),
+                            'label' => Text::_('Gestión de retornos colectivos cumplidos'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false)
                             )
                         )
                     )
                 ),
                 'users' => array(
-                    'label'   => _('Gestión de usuarios'),
+                    'label'   => Text::_('Gestión de usuarios'),
                     'options' => array (
                         'users' => array(
-                            'label' => _('Listado de usuarios'),
+                            'label' => Text::_('Listado de usuarios'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'add' => array('label' => _('Creando Usuario'), 'item' => true),
-                                'edit' => array('label' => _('Editando Usuario'), 'item' => true),
-                                'manage' => array('label' => _('Gestionando Usuario'), 'item' => true),
-                                'impersonate' => array('label' => _('Suplantando al Usuario'), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'add' => array('label' => Text::_('Creando Usuario'), 'item' => true),
+                                'edit' => array('label' => Text::_('Editando Usuario'), 'item' => true),
+                                'manage' => array('label' => Text::_('Gestionando Usuario'), 'item' => true),
+                                'impersonate' => array('label' => Text::_('Suplantando al Usuario'), 'item' => true)
                             )
                         ),
                         'worth' => array(
-                            'label' => _('Niveles de meritocracia'),
+                            'label' => Text::_('Niveles de meritocracia'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'edit' => array('label' => _('Editando Nivel'), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'edit' => array('label' => Text::_('Editando Nivel'), 'item' => true)
                             )
                         ),
                         'mailing' => array(
-                            'label' => _('Comunicaciones'),
+                            'label' => Text::_('Comunicaciones'),
                             'actions' => array(
-                                'list' => array('label' => _('Seleccionando destinatarios'), 'item' => false),
-                                'edit' => array('label' => _('Escribiendo contenido'), 'item' => false),
-                                'send' => array('label' => _('Comunicación enviada'), 'item' => false)
+                                'list' => array('label' => Text::_('Seleccionando destinatarios'), 'item' => false),
+                                'edit' => array('label' => Text::_('Escribiendo contenido'), 'item' => false),
+                                'send' => array('label' => Text::_('Comunicación enviada'), 'item' => false)
                             )
                         ),
                         'sended' => array(
-                            'label' => _('Historial envios'),
+                            'label' => Text::_('Historial envios'),
                             'actions' => array(
-                                'list' => array('label' => _('Emails enviados'), 'item' => false)
+                                'list' => array('label' => Text::_('Emails enviados'), 'item' => false)
                             )
                         )/*,
                         'useradd' => array(
@@ -5374,26 +5374,26 @@ namespace Goteo\Controller {
                     )
                 ),
                 'accounting' => array(
-                    'label'   => _('Gestión de aportes y transacciones'),
+                    'label'   => Text::_('Gestión de aportes y transacciones'),
                     'options' => array (
                         'invests' => array(
-                            'label' => _('Aportes a Proyectos'),
+                            'label' => Text::_('Aportes a Proyectos'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'add'  => array('label' => _('Aporte manual'), 'item' => false),
-                                'move'  => array('label' => _('Reubicando el aporte'), 'item' => true),
-                                'details' => array('label' => _('Detalles del aporte'), 'item' => true),
-                                'execute' => array('label' => _('Ejecución del cargo ahora mismo'), 'item' => true),
-                                'cancel' => array('label' => _('Cancelando aporte'), 'item' => true),
-                                'report' => array('label' => _('Informe de proyecto'), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'add'  => array('label' => Text::_('Aporte manual'), 'item' => false),
+                                'move'  => array('label' => Text::_('Reubicando el aporte'), 'item' => true),
+                                'details' => array('label' => Text::_('Detalles del aporte'), 'item' => true),
+                                'execute' => array('label' => Text::_('Ejecución del cargo ahora mismo'), 'item' => true),
+                                'cancel' => array('label' => Text::_('Cancelando aporte'), 'item' => true),
+                                'report' => array('label' => Text::_('Informe de proyecto'), 'item' => true)
                             )
                         ),
                         'accounts' => array(
-                            'label' => _('Transacciones económicas'),
+                            'label' => Text::_('Transacciones económicas'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'details' => array('label' => _('Detalles de la transacción'), 'item' => true),
-                                'viewer' => array('label' => _('Viendo logs'), 'item' => false)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'details' => array('label' => Text::_('Detalles de la transacción'), 'item' => true),
+                                'viewer' => array('label' => Text::_('Viendo logs'), 'item' => false)
                             )
                         )/*,
                         'credits' => array(
@@ -5408,75 +5408,75 @@ namespace Goteo\Controller {
                     )
                 ),
                 'home' => array(
-                    'label'   => _('Portada'),
+                    'label'   => Text::_('Portada'),
                     'options' => array (
                         'news' => array(
-                            'label' => _('Micronoticias'),
+                            'label' => Text::_('Micronoticias'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'add'  => array('label' => _('Nueva Micronoticia'), 'item' => false),
-                                'edit' => array('label' => _('Editando Micronoticia'), 'item' => true),
-                                'translate' => array('label' => _('Traduciendo Micronoticia'), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'add'  => array('label' => Text::_('Nueva Micronoticia'), 'item' => false),
+                                'edit' => array('label' => Text::_('Editando Micronoticia'), 'item' => true),
+                                'translate' => array('label' => Text::_('Traduciendo Micronoticia'), 'item' => true)
                             )
                         ),
                         'banners' => array(
-                            'label' => _('Banners'),
+                            'label' => Text::_('Banners'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'add'  => array('label' => _('Nuevo Banner'), 'item' => false),
-                                'edit' => array('label' => _('Editando Banner'), 'item' => true),
-                                'translate' => array('label' => _('Traduciendo Banner'), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'add'  => array('label' => Text::_('Nuevo Banner'), 'item' => false),
+                                'edit' => array('label' => Text::_('Editando Banner'), 'item' => true),
+                                'translate' => array('label' => Text::_('Traduciendo Banner'), 'item' => true)
                             )
                         ),
                         'posts' => array(
-                            'label' => _('Carrusel de blog'),
+                            'label' => Text::_('Carrusel de blog'),
                             'actions' => array(
-                                'list' => array('label' => _('Ordenando'), 'item' => false),
-                                'add'  => array('label' => _('Colocando Entrada en la portada'), 'item' => false)
+                                'list' => array('label' => Text::_('Ordenando'), 'item' => false),
+                                'add'  => array('label' => Text::_('Colocando Entrada en la portada'), 'item' => false)
                             )
                         ),
                         'promote' => array(
-                            'label' => _('Proyectos destacados'),
+                            'label' => Text::_('Proyectos destacados'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'add'  => array('label' => _('Nuevo Destacado'), 'item' => false),
-                                'edit' => array('label' => _('Editando Destacado'), 'item' => true),
-                                'translate' => array('label' => _('Traduciendo Destacado'), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'add'  => array('label' => Text::_('Nuevo Destacado'), 'item' => false),
+                                'edit' => array('label' => Text::_('Editando Destacado'), 'item' => true),
+                                'translate' => array('label' => Text::_('Traduciendo Destacado'), 'item' => true)
                             )
                         ),
                         'footer' => array(
-                            'label' => _('Entradas en el footer'),
+                            'label' => Text::_('Entradas en el footer'),
                             'actions' => array(
-                                'list' => array('label' => _('Ordenando'), 'item' => false),
-                                'add'  => array('label' => _('Colocando Entrada en el footer'), 'item' => false)
+                                'list' => array('label' => Text::_('Ordenando'), 'item' => false),
+                                'add'  => array('label' => Text::_('Colocando Entrada en el footer'), 'item' => false)
                             )
                         ),
                         'feed' => array(
-                            'label' => _('Actividad reciente'),
+                            'label' => Text::_('Actividad reciente'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false)
                             )
                         )
                     )
                 ),
                 'sponsors' => array(
-                    'label'   => _('Convocatorias de patrocinadores'),
+                    'label'   => Text::_('Convocatorias de patrocinadores'),
                     'options' => array (
                         'sponsors' => array(
-                            'label' => _('Apoyos institucionales'),
+                            'label' => Text::_('Apoyos institucionales'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'add'  => array('label' => _('Nuevo Patrocinador'), 'item' => false),
-                                'edit' => array('label' => _('Editando Patrocinador'), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'add'  => array('label' => Text::_('Nuevo Patrocinador'), 'item' => false),
+                                'edit' => array('label' => Text::_('Editando Patrocinador'), 'item' => true)
                             )
                         ),
                         'campaigns' => array(
-                            'label' => _('Gestión de campañas'),
+                            'label' => Text::_('Gestión de campañas'),
                             'actions' => array(
-                                'list' => array('label' => _('Listando'), 'item' => false),
-                                'add'  => array('label' => _('Nueva Campaña'), 'item' => false),
-                                'edit' => array('label' => _('Editando Campaña'), 'item' => true),
-                                'report' => array('label' => _('Informe de estado de la Campaña'), 'item' => true)
+                                'list' => array('label' => Text::_('Listando'), 'item' => false),
+                                'add'  => array('label' => Text::_('Nueva Campaña'), 'item' => false),
+                                'edit' => array('label' => Text::_('Editando Campaña'), 'item' => true),
+                                'report' => array('label' => Text::_('Informe de estado de la Campaña'), 'item' => true)
                             )
                         )/*,
                         'nodes' => array(

--- a/core/common.php
+++ b/core/common.php
@@ -18,8 +18,36 @@
  *
  */
 
-
 namespace {
+
+	require_once("core/registry.php");
+
+
+	class GoteoLogLevel {
+		const DEBUG = 10;
+		const INFO = 20;
+		const NOTICE = 25;
+		const WARNING = 30;
+		const ERROR = 40;
+		const CRITICAL = 50;
+	};
+
+	class TinyLogger {
+		var $level_cutoff;
+
+		public function __construct($cutoff = GoteLogLevel::DEBUG) {
+			$this->level_cutoff = $cutoff;
+		}
+
+		public function log($msg, $level) {
+			if($level >= $this->level_cutoff) {
+				error_log($msg);
+			}
+		}
+	}
+
+	$logger = new TinyLogger(GoteoLogLevel::DEBUG);
+	Goteo\Core\Registry::set('log', $logger);
 
     /**
      * Traza información sobre el recurso especificado de forma legible.
@@ -38,6 +66,10 @@ namespace {
     function dump ($resource = null) {
         echo '<pre>' . var_dump($resource) . '</pre>';
     }
+
+	function _log($msg, $level = GoteoLogLevel::DEBUG) {
+		Goteo\Core\Registry::get('log')->log($msg, $level);
+	}
 
     /**
      * Genera un mktime (UNIX_TIMESTAMP) a partir de una fecha (DATE/DATETIME/TIMESTAMP)

--- a/core/registry.php
+++ b/core/registry.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Goteo\Core {
+
+	class Registry {
+
+		private static $instance = null;
+
+		public static function get($key){
+			return self::getInstance()->$key;
+		}
+
+		public static function set ($key, $val){
+			if (!is_string($key)){
+				return false;
+			}
+			self::getInstance()->$key = $val;
+		}
+
+		public static function delete($key){
+			$return = false;
+			if (self::exist($key)){
+				unset ( self::getInstance()->$key );
+				$return = true;
+			}
+			return $return;
+		}
+
+		public static function exist($key) {
+			$return = false;
+			if (self::getInstance()->$key){
+				$return = true;
+			}
+			return $return;
+		}
+
+		public function __set($key, $val){
+			$this->$key = $val;
+		}
+
+		public function __get($key){
+			return $this->$key;
+		}
+
+		protected static function getInstance() {
+			if (!( self::$instance instanceof Registry ) || self::$instance == null) {
+				self::$instance = new Registry();
+			}
+			return self::$instance;
+		}
+
+		private function __construct() {}
+		private function __clone() {}
+
+	} // class
+
+} // ns

--- a/index.php
+++ b/index.php
@@ -20,14 +20,26 @@
 
 use Goteo\Core\Resource,
     Goteo\Core\Error,
+	Goteo\Core\Registry,
     Goteo\Core\Redirection,
     Goteo\Core\ACL,
     Goteo\Library\Text,
     Goteo\Library\Message,
-    Goteo\Library\Lang;
+	Goteo\Library\i18n\Locale,
+    Goteo\Library\i18n\Lang;
+
+
+if( !file_exists("config.php") ) {
+	$msg = "This instance of Goteo doesn't seem to be configured, please read the deployment guide, configure and try again.";
+	error_log($msg);
+	echo "<div id='failure'><h1>{$msg}</h1></div>";
+	die;
+}
 
 require_once 'config.php';
 require_once 'core/common.php';
+require_once 'library/i18n/Locale.php';
+require_once 'library/i18n/Lang.php';
 
 // Include path
 //set_include_path(GOTEO_PATH . PATH_SEPARATOR . '.');
@@ -36,7 +48,7 @@ require_once 'core/common.php';
 spl_autoload_register(
 
     function ($cls) {
-
+		//echo "Trying to autoload {$cls}...";
         $file = __DIR__ . '/' . implode('/', explode('\\', strtolower(substr($cls, 6)))) . '.php';
         $file = realpath($file);
 
@@ -49,6 +61,7 @@ spl_autoload_register(
         }
 
         if ($file !== false) {
+			//echo "Autoloading {$file}...";
             include $file;
         }
 
@@ -76,8 +89,11 @@ session_start();
 // set Lang
 Lang::set();
 // change current locale
-$locale = Lang::locale();
-Lang::gettext( $locale, \GOTEO_GETTEXT_DOMAIN );
+$locale_name = Lang::locale();
+$locale = new Locale($config['locale']);
+$locale->set($locale_name);
+Registry::set('locale', $locale);
+
 
 // Get URI without query string
 $uri = strtok($_SERVER['REQUEST_URI'], '?');

--- a/library/PHP-Gettext/Autoload.php
+++ b/library/PHP-Gettext/Autoload.php
@@ -1,0 +1,104 @@
+<?php
+
+if( ! extension_loaded('gettext') ) {
+	
+	require_once( dirname( __FILE__ )."/Gettext.php" );
+	require_once( dirname( __FILE__ )."/PHP.php" );
+		
+	global $__gettext_info__;
+	$__gettext_info__ = array();
+	
+	global $__gettext_object__;
+	$__gettext_object__ = NULL;
+	
+	global $__gettext_object_array__;
+	$__gettext_object_array__ = array();
+	
+	function bind_textdomain_codeset( $domain, $codeset )
+	{
+		global $__gettext_info__;
+		$__gettext_info__[$domain]["codeset"] = $codeset;
+	}
+	
+	function bindtextdomain( $domain, $directory )
+	{
+		global $__gettext_info__;
+		$__gettext_info__[$domain]["directory"] = $directory;
+	}
+	
+	function textdomain( $domain )
+	{
+		global $__gettext_info__;
+				
+		if( ! array_key_exists( $domain, $__gettext_info__ ) )
+			return;
+		
+		if( ! array_key_exists( "directory", $__gettext_info__[$domain] ) )
+			return;
+		
+		$directory = $__gettext_info__[$domain]["directory"];
+		$codeset = array_key_exists( "codeset", $__gettext_info__[$domain] )
+			? $__gettext_info__[$domain]["codeset"]
+			: "UTF-8";
+		
+		$locale = setlocale( LC_ALL, 0 );
+
+		global $__gettext_object__;
+		$__gettext_object__ = new Gettext_PHP( $directory, $domain, $locale );
+		$__gettext_object_array__[$domain] = $__gettext_object__;
+	}
+	
+	function gettext( $message )
+	{
+		global $__gettext_object__;
+		if( is_null( $__gettext_object__ ) )
+			return $message;
+
+		return $__gettext_object__->gettext( $message );
+	}
+	
+	function _( $message )
+	{
+		return gettext( $message );
+	}
+	
+	function ngettext( $msgid1, $msgid2, $n )
+	{
+		global $__gettext_object__;
+		if( is_null( $__gettext_object__ ) )
+			return $msgid1;
+		
+		return $__gettext_object__->ngettext( $msgid1, $msgid2, $n );
+	}
+	
+	function dgettext( $domain, $message )
+	{
+		global $__gettext_object_array__;
+		if( ! array_key_exists( $domain, $__gettext_object_array__ ) )
+			return $message;
+		
+		return $__gettext_object_array__[$domain]->gettext( $message );
+	}
+	
+	function dngettext( $domain, $msgid1, $msgid2, $n )
+	{
+		global $__gettext_object_array__;
+		if( ! array_key_exists( $domain, $__gettext_object_array__ ) )
+			return $msgid1;
+		
+		return $__gettext_object_array__[$domain]->ngettext( $msgid1, $msgid2, $n );
+	}
+	
+	function dcgettext( $domain, $message, $category )
+	{
+		throw new Exception( "not implemented" );
+	}
+	
+	function dcngettext( $domain , $msgid1 , $msgid2 , $n , $category )
+	{
+		throw new Exception( "not implemented" );
+	}
+	
+}
+
+?>

--- a/library/PHP-Gettext/Extension.php
+++ b/library/PHP-Gettext/Extension.php
@@ -1,0 +1,75 @@
+<?php
+/*
+ * Copyright (c) 2009 David Soria Parra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+/**
+ * Gettext implementation in PHP
+ *
+ * @copyright (c) 2009 David Soria Parra <sn_@gmx.net>
+ * @author David Soria Parra <sn_@gmx.net>
+ */
+class Gettext_Extension extends Gettext
+{
+    /**
+     * Initialize a new gettext class
+     *
+     * @param String $mofile The file to parse
+     */
+    public function __construct($directory, $domain, $locale)
+    {
+        setlocale(LC_ALL, $locale);
+        bindtextdomain($domain, $directory);
+        textdomain($domain);
+    }
+
+    /**
+     * Return a translated string
+     *
+     * If the translation is not found, the original passed message
+     * will be returned.
+     *
+     * @return Translated message
+     */
+    public function gettext($msg)
+    {
+        return gettext($msg);
+    }
+
+    /**
+     * Return a translated string in it's plural form
+     *
+     * Returns the given $count (e.g second, third,...) plural form of the
+     * given string. If the id is not found and $num == 1 $msg is returned,
+     * otherwise $msg_plural
+     *
+     * @param String $msg The message to search for
+     * @param String $msg_plural A fallback plural form
+     * @param Integer $count Which plural form
+     *
+     * @return Translated string
+     */
+    public function ngettext($msg, $msg_plural, $count)
+    {
+        return ngettext($msg, $msg_plural, $count);
+    }
+}

--- a/library/PHP-Gettext/Gettext.php
+++ b/library/PHP-Gettext/Gettext.php
@@ -1,0 +1,89 @@
+<?php
+/*
+ * Copyright (c) 2009 David Soria Parra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+require_once 'PHP.php';
+require_once 'Extension.php';
+
+/**
+ * Gettext implementation in PHP
+ *
+ * @copyright (c) 2009 David Soria Parra <sn_@gmx.net>
+ * @author David Soria Parra <sn_@gmx.net>
+ */
+abstract class Gettext
+{
+    private static $instance = null;
+
+    /**
+     * Return a translated string
+     *
+     * If the translation is not found, the original passed message
+     * will be returned.
+     *
+     * @param String $msg The message to translate
+     * 
+     * @return Translated message
+     */
+    public abstract function gettext($msg);
+
+    /**
+     * Return a translated string in it's plural form
+     *
+     * Returns the given $count (e.g second, third,...) plural form of the
+     * given string. If the id is not found and $num == 1 $msg is returned,
+     * otherwise $msg_plural
+     *
+     * @param String $msg The message to search for
+     * @param String $msg_plural A fallback plural form
+     * @param Integer $count Which plural form
+     *
+     * @return Translated string
+     */
+    public abstract function ngettext($msg1, $msg2, $count);
+
+    /**
+     * Returns an instance of a gettext implementation depending on
+     * the capabilities of the PHP installation. If the gettext extension
+     * is loaded, we use the native gettext() bindings, otherwise we use
+     * an own implementation
+     *
+     * @param String $directory Directory to search the mo files in
+     * @param String $domain    The current domain
+     * @param String $locale    The local
+     *
+     * @return Gettext An instance of a Gettext implementation
+     */
+    public static function getInstance($directory, $domain, $locale)
+    {
+        $key = $directory . $domain . $locale;
+        if (!isset(self::$instance[$key])) {
+            if (extension_loaded('gettext')) {
+                self::$instance[$key] = new Gettext_Extension($directory, $domain, $locale);
+            } else {
+                self::$instance[$key] = new Gettext_PHP($directory, $domain, $locale);
+            }
+        }
+
+        return self::$instance[$key];
+    }
+}

--- a/library/PHP-Gettext/PHP.php
+++ b/library/PHP-Gettext/PHP.php
@@ -1,0 +1,255 @@
+<?php
+/*
+ * Copyright (c) 2009 David Soria Parra
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+/**
+ * Gettext implementation in PHP
+ *
+ * @copyright (c) 2009 David Soria Parra <sn_@gmx.net>
+ * @author David Soria Parra <sn_@gmx.net>
+ */
+class Gettext_PHP extends Gettext
+{
+    /**
+     * First magic word in the MO header
+     */
+    const MAGIC1 = "\xde\x12\x04\x95";
+
+    /**
+     * Second magic word in the MO header
+     */
+    const MAGIC2 = "\x95\x04\x12\xde";
+
+    protected $mofile;
+    protected $translationTable = array();
+    protected $parsed = false;
+
+    /**
+     * Initialize a new gettext class
+     *
+     * @param String $mofile The file to parse
+     */
+    public function __construct($directory, $domain, $locale)
+    {
+        $this->mofile = sprintf("%s/%s/LC_MESSAGES/%s.mo", $directory,
+                            $locale, $domain);
+    }
+
+    /**
+     * Parse the MO file header and returns the table
+     * offsets as described in the file header.
+     *
+     * If an exception occured, null is returned. This is intentionally
+     * as we need to get close to ext/gettexts beahvior.
+     *
+     * @oaram Ressource $fp The open file handler to the MO file
+     *
+     * @return An array of offset
+     */
+    private function parseHeader($fp)
+    {
+        $magic   = fread($fp, 4);
+        $data   = fread($fp, 4);
+        $header = unpack("lrevision", $data);
+        
+        if (self::MAGIC1 != $magic
+           && self::MAGIC2 != $magic) {
+            return null;
+        }
+
+        if (0 != $header['revision']) {
+            return null;
+        }
+
+        $data    = fread($fp, 4 * 5);
+        $offsets = unpack("lnum_strings/lorig_offset/"
+                          . "ltrans_offset/lhash_size/lhash_offset", $data);
+        return $offsets;
+    }
+
+    /**
+     * Parse and returns the string offsets in a a table. Two table can be found in
+     * a mo file. The table with the translations and the table with the original
+     * strings. Both contain offsets to the strings in the file.
+     *
+     * If an exception occured, null is returned. This is intentionally
+     * as we need to get close to ext/gettexts beahvior.
+     *
+     * @param Ressource $fp     The open file handler to the MO file
+     * @param Integer   $offset The offset to the table that should be parsed
+     * @param Integer   $num    The number of strings to parse
+     *
+     * @return Array of offsets
+     */
+    private function parseOffsetTable($fp, $offset, $num)
+    {
+        if (fseek($fp, $offset, SEEK_SET) < 0) {
+            return null;
+        }
+
+        $table = array();
+        for ($i = 0; $i < $num; $i++) {
+            $data    = fread($fp, 8);
+            $table[] = unpack("lsize/loffset", $data);
+        }
+
+        return $table;
+    }
+
+    /**
+     * Parse a string as referenced by an table. Returns an
+     * array with the actual string.
+     *
+     * @param Ressource $fp    The open file handler to the MO fie
+     * @param Array     $entry The entry as parsed by parseOffsetTable()
+     *
+     * @return Parsed string
+     */
+    private function parseEntry($fp, $entry)
+    {
+        if (fseek($fp, $entry['offset'], SEEK_SET) < 0) {
+            return null;
+        }
+        if ($entry['size'] > 0) {
+            return fread($fp, $entry['size']);
+        }
+
+       return '';
+    }
+
+
+    /**
+     * Parse the MO file
+     *
+     * @return void
+     */
+    private function parse()
+    {
+        $this->translationTable = array();
+
+        if (!file_exists($this->mofile)) {
+            return;
+        }
+
+        $filesize = filesize($this->mofile);
+        if ($filesize < 4 * 7) {
+            return;
+        }
+
+        /* check for filesize */
+        $fp = fopen($this->mofile, "rb");
+
+        $offsets = $this->parseHeader($fp);
+        if (null == $offsets || $filesize < 4 * ($offsets['num_strings'] + 7)) {
+            fclose($fp);
+            return;
+        }
+
+        $transTable = array();
+        $table = $this->parseOffsetTable($fp, $offsets['trans_offset'],
+                    $offsets['num_strings']);
+        if (null == $table) {
+            fclose($fp);
+            return;
+        }
+
+        foreach ($table as $idx => $entry) {
+            $transTable[$idx] = $this->parseEntry($fp, $entry);
+        }
+
+        $table = $this->parseOffsetTable($fp, $offsets['orig_offset'],
+                    $offsets['num_strings']);
+        foreach ($table as $idx => $entry) {
+            $entry = $this->parseEntry($fp, $entry);
+
+            $formes      = explode(chr(0), $entry);
+            $translation = explode(chr(0), $transTable[$idx]);
+            foreach($formes as $form) {
+                $this->translationTable[$form] = $translation;
+            }
+        }
+
+        fclose($fp);
+
+        $this->parsed = true;
+    }
+
+    /**
+     * Return a translated string
+     *
+     * If the translation is not found, the original passed message
+     * will be returned.
+     *
+     * @return Translated message
+     */
+    public function gettext($msg)
+    {
+        if (!$this->parsed) {
+            $this->parse();
+        }
+
+        if (array_key_exists($msg, $this->translationTable)) {
+            return $this->translationTable[$msg][0];
+        }
+        return $msg;
+    }
+
+    /**
+     * Return a translated string in it's plural form
+     *
+     * Returns the given $count (e.g second, third,...) plural form of the
+     * given string. If the id is not found and $num == 1 $msg is returned,
+     * otherwise $msg_plural
+     *
+     * @param String $msg The message to search for
+     * @param String $msg_plural A fallback plural form
+     * @param Integer $count Which plural form
+     *
+     * @return Translated string
+     */
+    public function ngettext($msg, $msg_plural, $count)
+    {
+        if (!$this->parsed) {
+            $this->parse();
+        }
+
+        $msg = (string) $msg;
+
+        if (array_key_exists($msg, $this->translationTable)) {
+            $translation = $this->translationTable[$msg];
+            /* the gettext api expect an unsigned int, so we just fake 'cast' */
+            if ($count <= 0 || count($translation) < $count) {
+                $count = count($translation);
+            }
+            return $translation[$count - 1];
+        }
+
+        /* not found, handle count */
+        if (1 == $count) {
+            return $msg;
+        } else {
+            return $msg_plural;
+        }
+    }
+}
+

--- a/library/PHP-Gettext/README.md
+++ b/library/PHP-Gettext/README.md
@@ -1,0 +1,26 @@
+About
+-----
+This is a PHP Implementation of Gettext.
+
+License Information
+-------------------
+
+Copyright (c) 2009 David Soria Parra
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/library/PHP-Gettext/tests/AllTests.php
+++ b/library/PHP-Gettext/tests/AllTests.php
@@ -1,0 +1,21 @@
+<?php
+//require_once 'PHPUnit/Framework.php';
+ 
+require_once 'InstanceTest.php';
+require_once 'ExtensionTest.php';
+require_once 'PHPTest.php';
+ 
+class AllTests
+{
+    public static function suite()
+    {
+        $suite = new PHPUnit_Framework_TestSuite('Project');
+ 
+        $suite->addTestSuite('InstanceTest');
+        $suite->addTestSuite('ExtensionTest');
+        $suite->addTestSuite('PHPTest');
+ 
+        return $suite;
+    }
+}
+

--- a/library/PHP-Gettext/tests/ExtensionTest.php
+++ b/library/PHP-Gettext/tests/ExtensionTest.php
@@ -1,0 +1,39 @@
+<?php
+//require_once 'PHPUnit/Framework.php';
+require_once '../Gettext.php';
+
+class ExtensionTest extends PHPUnit_Framework_TestCase
+{
+    public function testGettext()
+    {
+        $g = new Gettext_Extension('./', 'gettext', 'de');
+        $this->assertEquals('Datei existiert nicht', $g->gettext('File does not exist'));
+        $this->assertEquals('Datei ist zu klein', $g->gettext('File is too small'));
+        $this->assertEquals('Foobar', $g->gettext('Foobar'));
+        $this->assertContains('Last-Translator', $g->gettext(null));
+    }
+
+    public function testNonexistantFile()
+    {
+        $g = new Gettext_Extension('./', 'gettext', 'notexistent');
+        $this->assertEquals('Foobar', $g->gettext('Foobar'));
+    }
+
+    public function testNgettext()
+    {
+        $g = new Gettext_Extension('./', 'gettext', 'de');
+        $this->assertEquals('Datei existiert nicht', $g->ngettext('File does not exist', 'Files donnot exists', 1));
+        $this->assertEquals('Datei ist zu klein', $g->ngettext('File is too small', 'Files are too small', 1));
+        $this->assertEquals('Foobar', $g->ngettext('Foobar', 'Foobar', 1));
+
+        $this->assertEquals('Datei existiert nicht', $g->ngettext('File does not exist', 'Files donnot exists', 2));
+        $this->assertEquals('Dateien sind zu klein', $g->ngettext('File is too small', 'Files are too small', 2));
+        $this->assertEquals('Foobar', $g->ngettext('Foobar', 'Foobar', 2));
+
+        $this->assertContains('Last-Translator', $g->ngettext(null, null, 1));
+
+        $this->assertEquals('Dateien sind zu klein', $g->ngettext('File is too small', 'Files are too small', -1));
+        $this->assertEquals('Dateien sind zu klein', $g->ngettext('File is too small', 'Files are too small', 0));
+    }
+}
+

--- a/library/PHP-Gettext/tests/InstanceTest.php
+++ b/library/PHP-Gettext/tests/InstanceTest.php
@@ -1,0 +1,49 @@
+<?php
+//require_once 'PHPUnit/Framework.php';
+require_once '../Gettext.php';
+
+class InstanceTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testGettext()
+    {
+        $g = Gettext::getInstance('./', 'gettext', 'de');
+        $this->assertEquals('Datei existiert nicht', $g->gettext('File does not exist'));
+        $this->assertEquals('Datei ist zu klein', $g->gettext('File is too small'));
+        $this->assertEquals('Foobar', $g->gettext('Foobar'));
+        $this->assertContains('Last-Translator', $g->gettext(null));
+    }
+
+    public function testNonexistantFile()
+    {
+        $g = Gettext::getInstance('./', 'gettext', 'notexistent');
+        $this->assertEquals('Foobar', $g->gettext('Foobar'));
+    }
+
+    public function testGetInstance()
+    {
+        $this->assertFalse(Gettext::getInstance('./', 'gettext', '1') ===
+            Gettext::getInstance('./', 'gettext', '2'));
+        $this->assertTrue(Gettext::getInstance('./', 'gettext', '1') ===
+            Gettext::getInstance('./', 'gettext', '1'));
+    }
+
+    public function testNgettext()
+    {
+        $g = Gettext::getInstance('./', 'gettext', 'de');
+        $this->assertEquals('Datei existiert nicht', $g->gettext('File does not exist'));
+        $this->assertEquals('Datei existiert nicht', $g->ngettext('File does not exist', 'Files donnot exists', 1));
+        $this->assertEquals('Datei ist zu klein', $g->ngettext('File is too small', 'Files are too small', 1));
+        $this->assertEquals('Foobar', $g->ngettext('Foobar', 'Foobar', 1));
+
+        $this->assertEquals('Datei existiert nicht', $g->ngettext('File does not exist', 'Files donnot exists', 2));
+        $this->assertEquals('Dateien sind zu klein', $g->ngettext('File is too small', 'Files are too small', 2));
+        $this->assertEquals('Foobar', $g->ngettext('Foobar', 'Foobar', 2));
+
+        $this->assertContains('Last-Translator', $g->ngettext(null, null, 1));
+
+        $this->assertEquals('Dateien sind zu klein', $g->ngettext('File is too small', 'Files are too small', -1));
+        $this->assertEquals('Dateien sind zu klein', $g->ngettext('File is too small', 'Files are too small', 0));
+    }
+}
+

--- a/library/PHP-Gettext/tests/PHPTest.php
+++ b/library/PHP-Gettext/tests/PHPTest.php
@@ -1,0 +1,41 @@
+<?php
+//require_once 'PHPUnit/Framework.php';
+require_once '../Gettext.php';
+
+class PHPTest extends PHPUnit_Framework_TestCase
+{
+
+    public function testGettext()
+    {
+        $g = new Gettext_PHP('./', 'gettext', 'de');
+        $this->assertEquals('Datei existiert nicht', $g->gettext('File does not exist'));
+        $this->assertEquals('Datei ist zu klein', $g->gettext('File is too small'));
+        $this->assertEquals('Foobar', $g->gettext('Foobar'));
+        $this->assertContains('Last-Translator', $g->gettext(null));
+    }
+
+    public function testNonexistantFile()
+    {
+        $g = new Gettext_PHP('./', 'gettext', 'notexistent');
+        $this->assertEquals('Foobar', $g->gettext('Foobar'));
+    }
+
+    public function testNgettext()
+    {
+        $g = new Gettext_PHP('./', 'gettext', 'de');
+        $this->assertEquals('Datei existiert nicht', $g->gettext('File does not exist'));
+        $this->assertEquals('Datei existiert nicht', $g->ngettext('File does not exist', 'Files donnot exists', 1));
+        $this->assertEquals('Datei ist zu klein', $g->ngettext('File is too small', 'Files are too small', 1));
+        $this->assertEquals('Foobar', $g->ngettext('Foobar', 'Foobar', 1));
+
+        $this->assertEquals('Datei existiert nicht', $g->ngettext('File does not exist', 'Files donnot exists', 2));
+        $this->assertEquals('Dateien sind zu klein', $g->ngettext('File is too small', 'Files are too small', 2));
+        $this->assertEquals('Foobar', $g->ngettext('Foobar', 'Foobar', 2));
+
+        $this->assertContains('Last-Translator', $g->ngettext(null, null, 1));
+
+        $this->assertEquals('Dateien sind zu klein', $g->ngettext('File is too small', 'Files are too small', -1));
+        $this->assertEquals('Dateien sind zu klein', $g->ngettext('File is too small', 'Files are too small', 0));
+    }
+}
+

--- a/library/PHP-Gettext/tests/de.po
+++ b/library/PHP-Gettext/tests/de.po
@@ -1,0 +1,29 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2009-08-11 22:15+0200\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=ASCII\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
+
+
+#: PHP.php:65
+msgid "File does not exist"
+msgstr "Datei existiert nicht"
+
+#: PHP.php:70
+msgid "File is too small"
+msgid_plural "Files are too small"
+msgstr[0] "Datei ist zu klein"
+msgstr[1] "Dateien sind zu klein"

--- a/library/PHP-Gettext/tests/gettext.php
+++ b/library/PHP-Gettext/tests/gettext.php
@@ -1,0 +1,17 @@
+<?php
+
+include_once "Gettext.php";
+
+$dirname = realpath(dirname($_SERVER['SCRIPT_FILENAME']));
+$gn = new Gettext_PHP($dirname . "/", "gettext", "de");
+$ge = new Gettext_Extension($dirname . "/", "gettext", "de");
+var_dump($gn->gettext("File does not exist"));
+var_dump($ge->gettext("File does not exist"));
+var_dump($gn->gettext("File does not exist") == $ge->gettext("File does not exist"));
+var_dump($gn->ngettext("File is too small", "Files are too small", 1));
+var_dump($ge->ngettext("File is too small", "Files are too small", 1));
+var_dump($gn->ngettext("File is too small", "Files are too small", 1) == $ge->ngettext("File is too small", "Files are too small", 1));
+var_dump($gn->ngettext("File is too small", "Files are too small", 2));
+var_dump($ge->ngettext("File is too small", "Files are too small", 2));
+var_dump($gn->ngettext("File is too small", "Files are too small", 2) == $ge->ngettext("File is too small", "Files are too small", 2));
+

--- a/library/i18n/GettextTranslate.php
+++ b/library/i18n/GettextTranslate.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Goteo\Library\i18n {
+	require_once 'library/PHP-Gettext/Gettext.php';
+
+	class GettextTranslate {
+		var $locale;
+		var $gt;
+
+		public function __construct($_root, $_locale, $_domain) {
+			$this->locale = $_locale;
+			/* directory domain locale */
+			_log("GettextTranslate::ctor root={$_root}, locale={$_locale}, domain={$_domain}");
+			$this->gt = new \Gettext_PHP($_root, $_domain, $_locale);
+		}
+
+		public function text($msg) {
+			return $this->gt->gettext($msg);
+		}
+	} // class
+} // ns
+?>

--- a/library/i18n/Lang.php
+++ b/library/i18n/Lang.php
@@ -19,11 +19,12 @@
  */
 
 
-namespace Goteo\Library {
+namespace Goteo\Library\i18n {
 
-  require_once 'library/php-mo/php-mo.php';  // external library to compile .po gettext files on the fly
+	require_once 'library/php-mo/php-mo.php';  // external library to compile .po gettext files on the fly
 
 	use Goteo\Core\Model;
+
 	/*
 	 * Clase para sacar textos estáticos de la tabla text
 	 *  (por ahora utilizar gettext no nos compensa, quizás más adelante)
@@ -127,88 +128,8 @@ namespace Goteo\Library {
 			$sql = "SELECT locale FROM lang WHERE id = :id";
 			$query = Model::query($sql, array(':id' => \LANG));
 			return $query->fetchColumn();
-    }
-
-		static protected function gettextBinaryExists($locale, $domain) {
-			return \file_exists("locale/{$locale}/LC_MESSAGES/{$domain}.mo");
-		}
-		
-		static protected function localeExists($locale, $domain) {
-			return \file_exists("locale/{$locale}/LC_MESSAGES/{$domain}.po");
-		}
-		
-		static public function gettextSupported() {
-			return function_exists("gettext");
 		}
 
-		/**
-		 * Use the php.mo library to compile gettext .po files if the binary doesn't exist.
-		 *
-		 * @return true/false on success/failure
-		 */
-		static private function compileLanguageFile($locale, $domain) {
-				return \phpmo_convert( "locale/{$locale}/LC_MESSAGES/{$domain}.po" );
-		}
-
-		/**
-		 * bypass gettext caching by using a clever file-renaming 
-		 * mechanism described in http://blog.ghost3k.net/articles/php/11/gettext-caching-in-php
-		 */
-		static protected function spawnUncachedDomain($locale, $domain) {
-			// path to the .MO file that we should monitor
-			$filename = "locale/{$locale}/LC_MESSAGES/{$domain}.mo";
-			$mtime = \filemtime($filename); // check its modification time
-			// our new unique .MO file
-			$filename_new = "locale/{$locale}/LC_MESSAGES/{$domain}_{$mtime}.mo"; 
-
-			if (!\file_exists($filename_new)) {  // check if we have created it before
-	      // if not, create it now, by copying the original
-	      \copy($filename,$filename_new);
-				//error_log("creating new domain {$filename_new}");
-			}
-			// compute the new domain name
-			$domain_new = "{$domain}_{$mtime}";
-			
-			return $domain_new;
-		} 
-		
-		/**
-		 * Set gettext configuration to be used by PHP.
-		 *
-		 * @param $locale the string that determines the current locale (e.g. en_GB)
-		 * @param $domain the filename for the .po file used by gettext to load messages from
-		 */
-		static public function gettext($locale, $domain) {
-			if( !Lang::gettextSupported() ) { 
-				error_log("ERROR - GETTEXT not supported on this server, all texts will appear in spanish"); 
-				return; 
-			}
-			
-			\setlocale(\LC_TIME, $locale);
-			\putenv("LANG={$locale}");
-			\setlocale(LC_ALL, $locale);
-			
-			if( Lang::localeExists($locale, $domain) ) {
-				// determine if the language binary file exists, if not try to generate it automatically
-				if( !Lang::gettextBinaryExists($locale, $domain) ) {
-					Lang::compileLanguageFile($locale, $domain);
-					//error_log("compiling missing language file binary");
-				}
-
-				// generate a new uncached domain file if caching bypass featured is enabled
-				if(true == \GOTEO_GETTEXT_BYPASS_CACHING) {	
-					$domain = Lang::spawnUncachedDomain($locale, $domain);
-					//error_log("bypassing gettext caching");
-				}
-			
-				// configure settext domain
-				\bindtextdomain($domain, "locale");
-				\bind_textdomain_codeset($domain, 'UTF-8');
-				\textdomain($domain);
-			} else {
-				error_log("WARNING - Locale is not installed ${locale}");
-			}
-		}
 	} // class
 
 

--- a/library/i18n/Locale.php
+++ b/library/i18n/Locale.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Goteo\Library\i18n {
+
+	use Goteo\Core\Registry;
+	
+	require_once 'Lang.php';
+	require_once 'LocaleUtils.php';
+	require_once 'GettextTranslate.php';
+
+	class Locale {
+
+		var $engine;
+		var $options;
+		var $locale;
+		var $locale_best_fit;
+
+		public function __construct($cfg) {
+			$this->options = $cfg;
+		}
+
+		/**
+		 * Sets current locale to the best match from the installed ones
+		 * (e.g. if only 'en' locale is installed but $locale is set to 'en_GB'
+		 * $locale_best_fit will become 'en' instead). This allows for locale
+		 * fallbacks.
+		 *
+		 * @param type $currentlocale normalized locale string
+		 */
+		public function set($currentlocale) {
+			$this->locale = $currentlocale;
+			$available_locales = Locale::listAvailableLocales($this->options['gettext_root']);
+			//var_dump($available_locales);
+			$this->locale_best_fit = LocaleUtils::lookup($available_locales, $currentlocale);
+			_log("Setting locale to best available fit '{$this->locale_best_fit}'");
+
+			// configure gettext environment
+			$this->configGettext($this->options['gettext_root'],
+									$this->locale_best_fit,
+									$this->options['gettext_domain']);
+			
+			// inject translation object for current locale
+			$gt = new GettextTranslate($this->options['gettext_root'], 
+										$this->locale_best_fit,
+										$this->options['gettext_domain']);
+			Registry::set('translate', $gt);
+		}
+
+		/**
+		 * Returns a list with all the installed directories containing a locale.
+		 *
+		 * @param type $root root directory for locales in this Goteo install
+		 * @return array list of locales installed
+		 */
+		protected function listAvailableLocales($root) {
+			$retval = array();
+
+			foreach(glob($root.DIRECTORY_SEPARATOR.'*', GLOB_ONLYDIR) as $dir) {
+				array_push($retval, basename($dir) );
+			}
+
+			return $retval;
+		}
+
+		protected function domainFileExists($root, $locale, $domain) {
+			return \file_exists("{$root}/{$locale}/LC_MESSAGES/{$this->options['gettext_domain']}.mo");
+		}
+
+		protected function localeExists($root, $locale, $domain) {
+			return \file_exists("{$root}/{$locale}/LC_MESSAGES/{$domain}.po");
+		}
+
+		static public function gettextSupported() {
+			return function_exists("gettext");
+		}
+
+		/**
+		 * Use the php.mo library to compile gettext .po files if the binary doesn't exist.
+		 *
+		 * @return true/false on success/failure
+		 */
+		private function compileLanguageFile($root, $locale, $domain) {
+			return \phpmo_convert("{$root}/{$locale}/LC_MESSAGES/{$domain}.po");
+		}
+
+		/**
+		 * bypass gettext caching by using a clever file-renaming
+		 * mechanism described in http://blog.ghost3k.net/articles/php/11/gettext-caching-in-php
+		 */
+		protected function spawnUncachedDomain($root, $locale, $domain) {
+			// path to the .MO file that we should monitor
+			$filename = "{$root}/{$locale}/LC_MESSAGES/{$domain}.mo";
+			$mtime = \filemtime($filename); // check its modification time
+			// our new unique .MO file
+			$filename_new = "{$root}/{$locale}/LC_MESSAGES/{$domain}_{$mtime}.mo";
+
+			if (!\file_exists($filename_new)) {  // check if we have created it before
+				// if not, create it now, by copying the original
+				\copy($filename, $filename_new);
+				_log("creating new domain {$filename_new}");
+			}
+			// compute the new domain name
+			$domain_new = "{$domain}_{$mtime}";
+
+			return $domain_new;
+		}
+
+		/**
+		 * Set gettext configuration to be used by PHP.
+		 *
+		 * @param $locale the string that determines the current locale (e.g. en_GB)
+		 * @param $domain the filename for the .po file used by gettext to load messages from
+		 */
+		public function configGettext($root, $locale, $domain) {
+			if (!Locale::gettextSupported()) {
+				_log(GoteoLogLevel::WARNING, "GETTEXT not supported on this server, all texts will appear in spanish");
+				return;
+			}
+
+			\setlocale(\LC_TIME, $locale);
+			\putenv("LANG={$locale}");
+			\setlocale(LC_ALL, $locale);
+
+			if (Locale::localeExists($root, $locale, $domain)) {
+				// determine if the language binary file exists, if not try to generate it automatically
+				if (!Locale::domainFileExists($root, $locale, $domain)) {
+					Locale::compileLanguageFile($root, $locale, $domain);
+					_log("compiling missing language file binary");
+				}
+
+				// generate a new uncached domain file if caching bypass featured is enabled
+				if (true == $this->options['gettext_bypass_caching']) {
+					$domain = Locale::spawnUncachedDomain($root, $locale, $domain);
+					_log("bypassing gettext caching");
+				}
+
+				// configure settext domain
+				\bindtextdomain($domain, $root);
+				\bind_textdomain_codeset($domain, 'UTF-8');
+				\textdomain($domain);
+			} else {
+				_log("WARNING - Locale is not installed ${locale}");
+			}
+		}
+
+	} // class
+
+} // namespace
+?>

--- a/library/i18n/LocaleUtils.php
+++ b/library/i18n/LocaleUtils.php
@@ -1,0 +1,308 @@
+<?php
+/**
+ * Adapted for Goteo from Lithium ( http://lithify.me/ )
+ *
+ * @copyright     Copyright 2012, Union of RAD (http://union-of-rad.org)
+ * @license       http://opensource.org/licenses/bsd-license.php The BSD License
+ */
+
+//use BadMethodCallException;
+//use InvalidArgumentException;
+
+namespace Goteo\Library\i18n {
+	/**
+	 * The `Locale` class provides methods to deal with locale identifiers.  The locale
+	 * (here: _locale identifier_) is used to distinguish among different sets of common
+	 * preferences.
+	 *
+	 * In order to avoid unnecessary overhead all methods throughout the framework accepting
+	 * a locale require it to be well-formed according to the structure laid out below. For
+	 * assuring the correct format use `Locale::canonicalize()` once on the locale.
+	 *
+	 * However the methods within this class will also work with not-so-well-formed locales.
+	 * They accept both underscores and hyphens as separators between and don't care about the
+	 * case of the individual tags.
+	 *
+	 * The identifier used by Lithium is based in its structure upon Unicode's
+	 * language identifier and is compliant to BCP 47.
+	 *
+	 * `language[_Script][_TERRITORY][_VARIANT]`
+	 *  - `language` The spoken language, here represented by an ISO 639-1 code,
+	 *    where not available ISO 639-3 and ISO 639-5 codes are allowed too) tag.
+	 *    The tag should  be lower-cased and is required.
+	 *  - `Script` The tag should have it's first character capitalized, all others
+	 *    lower-cased. The tag is optional.
+	 *  - `TERRITORY` A geographical area, here represented by an ISO 3166-1 code.
+	 *     Should be all upper-cased and is optional.
+	 *  - `VARIANT` Should be all upper-cased and is optional.
+	 *
+	 * @link http://www.unicode.org/reports/tr35/tr35-12.html#Identifiers
+	 * @link http://www.rfc-editor.org/rfc/bcp/bcp47.txt
+	 * @link http://www.iana.org/assignments/language-subtag-registry
+	 */
+	class LocaleUtils {
+
+	  /**
+		 * Properties for locale tags.
+		 *
+		 * @var array
+		 */
+		protected static $_tags = array(
+			'language' => array('formatter' => 'strtolower'),
+			'script' => array('formatter' => array('strtolower', 'ucfirst')),
+			'territory' => array('formatter' => 'strtoupper'),
+			'variant' => array('formatter' => 'strtoupper')
+		);
+
+		/**
+		 * Magic method enabling `language`, `script`, `territory` and `variant`
+		 * methods to parse and retrieve individual tags from a locale.
+		 *
+		 * {{{
+		 *     Locale::language('en_US'); // returns 'en'
+		 *     Locale::territory('en_US'); // returns 'US'
+		 * }}}
+		 *
+		 * @see lithium\g11n\Locale::$_tags
+		 * @see lithium\g11n\Locale::decompose()
+		 * @param string $method
+		 * @param array $params
+		 * @return mixed
+		 */
+		public static function __callStatic($method, $params = array()) {
+			$tags = static::invokeMethod('decompose', $params);
+
+			if (!isset(static::$_tags[$method])) {
+				throw new \BadMethodCallException("Invalid locale tag `{$method}`.");
+			}
+			return isset($tags[$method]) ? $tags[$method] : null;
+		}
+
+		/**
+		 * Composes a locale from locale tags.  This is the pendant to `Locale::decompose()`.
+		 *
+		 * @param array $tags An array as obtained from `Locale::decompose()`.
+		 * @return string A locale with tags separated by underscores or `null`
+		 *         if none of the passed tags could be used to compose a locale.
+		 */
+		public static function compose($tags) {
+			$result = array();
+
+			foreach (static::$_tags as $name => $tag) {
+				if (isset($tags[$name])) {
+					$result[] = $tags[$name];
+				}
+			}
+			if ($result) {
+				return implode('_', $result);
+			}
+		}
+
+		/**
+		 * Parses a locale into locale tags.  This is the pendant to `Locale::compose()``.
+		 *
+		 * @param string $locale A locale in an arbitrary form (i.e. `'en_US'` or `'EN-US'`).
+		 * @return array Parsed language, script, territory and variant tags.
+		 * @throws InvalidArgumentException
+		 */
+		public static function decompose($locale) {
+			$regex  = '(?P<language>[a-z]{2,3})';
+			$regex .= '(?:[_-](?P<script>[a-z]{4}))?';
+			$regex .= '(?:[_-](?P<territory>[a-z]{2}))?';
+			$regex .= '(?:[_-](?P<variant>[a-z]{5,}))?';
+
+			if (!preg_match("/^{$regex}$/i", $locale, $matches)) {
+				throw new \InvalidArgumentException("Locale `{$locale}` could not be parsed.");
+			}
+			return array_filter(array_intersect_key($matches, static::$_tags));
+		}
+
+		/**
+		 * Returns a locale in its canonical form with tags formatted properly.
+		 *
+		 * @param string $locale A locale in an arbitrary form (i.e. `'ZH-HANS-HK_REVISED'`).
+		 * @return string A locale in it's canonical form (i.e. `'zh_Hans_HK_REVISED'`).
+		 */
+		public static function canonicalize($locale) {
+			$tags = static::decompose($locale);
+
+			foreach ($tags as $name => &$tag) {
+				foreach ((array) static::$_tags[$name]['formatter'] as $formatter) {
+					$tag = $formatter($tag);
+				}
+			}
+			return static::compose($tags);
+		}
+
+		/**
+		 * Cascades a locale.
+		 *
+		 * Usage:
+		 * {{{
+		 * Locale::cascade('en_US');
+		 * // returns array('en_US', 'en', 'root')
+		 *
+		 * Locale::cascade('zh_Hans_HK_REVISED');
+		 * // returns array('zh_Hans_HK_REVISED', 'zh_Hans_HK', 'zh_Hans', 'zh', 'root')
+		 * }}}
+		 *
+		 * @link http://www.unicode.org/reports/tr35/tr35-13.html#Locale_Inheritance
+		 * @param string $locale A locale in an arbitrary form (i.e. `'en_US'` or `'EN-US'`).
+		 * @return array Indexed array of locales (starting with the most specific one).
+		 */
+		public static function cascade($locale) {
+			$locales[] = $locale;
+
+			if ($locale === 'root') {
+				return $locales;
+			}
+			$tags = static::decompose($locale);
+
+			while (count($tags) > 1) {
+				array_pop($tags);
+				$locales[] = static::compose($tags);
+			}
+			$locales[] = 'root';
+			return $locales;
+		}
+
+		/**
+		 * Searches an array of locales for the best match to a locale. The locale
+		 * is iteratively simplified until either it matches one of the locales
+		 * in the list or the locale can't be further simplified.
+		 *
+		 * This method partially implements the lookup matching scheme as described
+		 * in RFC 4647, section 3.4 and thus does not strictly conform to the
+		 * specification.
+		 *
+		 * Differences to specification:
+		 * - No support for wildcards in the to-be-matched locales.
+		 * - No support for locales with private subtags.
+		 * - No support for a default return value.
+		 * - Passed locales are required to be in canonical form (i.e. `'ja_JP'`).
+		 *
+		 * @link http://www.ietf.org/rfc/rfc4647.txt
+		 * @param array $locales Locales to match against `$locale`.
+		 * @param string $locale A locale in it's canonical form (i.e. `'zh_Hans_HK_REVISED'`).
+		 * @return string The matched locale.
+		 */
+		public static function lookup($locales, $locale) {
+			$tags = static::decompose($locale);
+			$count = count($tags);
+			while ($count > 0) {
+				if (($key = array_search(static::compose($tags), $locales)) !== false) {
+					return $locales[$key];
+				} elseif ($count == 1) {
+					foreach ($locales as $currentLocale) {
+						if (strpos($currentLocale, current($tags) . '_') === 0) {
+							return $currentLocale;
+						}
+					}
+				}
+				if (($key = array_search(static::compose($tags), $locales)) !== false) {
+					return $locales[$key];
+				}
+				array_pop($tags);
+				$count = count($tags);
+			}
+		}
+
+		/**
+		 * Determines the preferred locale from a request or array. Optionally negotiates
+		 * the preferred locale with available locales.
+		 *
+		 * @see lithium\g11n\Locale::_preferredAction()
+		 * @see lithium\g11n\Locale::_preferredConsole()
+		 * @see lithium\g11n\Locale::lookup()
+		 * @param object|array $request An action or console request object or an array of locales.
+		 * @param array $available A list of locales to negotiate the preferred locale with.
+		 * @return string The preferred locale in it's canonical form (i.e. `'fr_CA'`).
+		 * @todo Rewrite this to remove hard-coded class names.
+		 */
+		public static function preferred($request, $available = null) {
+			if (is_array($request)) {
+				$result = $request;
+			} elseif ($request instanceof ActionRequest) {
+				$result = static::_preferredAction($request);
+			} elseif ($request instanceof ConsoleRequest) {
+				$result = static::_preferredConsole($request);
+			} else {
+				return null;
+			}
+			if (!$available) {
+				return array_shift($result);
+			}
+			foreach ((array) $result as $locale) {
+				if ($match = static::lookup($available, $locale)) {
+					return $match;
+				}
+			}
+		}
+
+		/**
+		 * Detects preferred locales from an action request by looking at the
+		 * `'Accept-Language'` header as described by RFC 2616, section 14.4.
+		 *
+		 * @link http://www.ietf.org/rfc/rfc2616.txt
+		 * @param object $request An instance of `lithium\action\Request`.
+		 * @return array Preferred locales in their canonical form (i.e. `'fr_CA'`).
+		 */
+		protected static function _preferredAction($request) {
+			$result = array();
+			$regex  = "/^\s*(?P<locale>\w\w(?:[-]\w\w)?)(?:;q=(?P<quality>(0|1|0\.\d+)))?\s*$/";
+
+			foreach (explode(',', $request->env('HTTP_ACCEPT_LANGUAGE')) as $part) {
+				if (preg_match($regex, $part, $matches)) {
+					$locale = static::canonicalize($matches['locale']);
+					$quality = isset($matches['quality']) ? $matches['quality'] : 1;
+					$result[$quality][] = $locale;
+				}
+			}
+
+			krsort($result);
+			$return = array();
+
+			foreach ($result as $locales) {
+				$return = array_merge($return, array_values($locales));
+			}
+			return $return;
+		}
+
+		/**
+		 * Detects preferred locales from a console request by looking at certain
+		 * environment variables. The environment variables may be present or not
+		 * depending on your system. If multiple variables are present the following
+		 * hierarchy is used: `'LANGUAGE'`,  `'LC_ALL'`, `'LANG'`.
+		 *
+		 * The locales of the `'LC_ALL'` and the `'LANG'` are formatted according
+		 * to the posix standard: `language(_territory)(.encoding)(@modifier)`.
+		 * Locales having such a format are automatically canonicalized and transformed
+		 * into the `Locale` class' format.
+		 *
+		 * @link http://www.linux.com/archive/feature/53781
+		 * @param object $request An instance of `lithium\console\Request`.
+		 * @return array Preferred locales in their canonical form (i.e. `'fr_CA'`).
+		 */
+		protected static function _preferredConsole($request) {
+			$regex = '(?P<locale>[\w\_]+)(\.|@|$)+';
+			$result = array();
+
+			if ($value = $request->env('LANGUAGE')) {
+				return explode(':', $value);
+			}
+			foreach (array('LC_ALL', 'LANG') as $variable)  {
+				$value = $request->env($variable);
+
+				if (!$value || $value == 'C' || $value == 'POSIX') {
+					continue;
+				}
+				if (preg_match("/{$regex}/", $value, $matches)) {
+					return (array) $matches['locale'];
+				}
+			}
+			return $result;
+		}
+	} // class
+
+} // ns
+?>

--- a/library/text.php
+++ b/library/text.php
@@ -22,6 +22,7 @@
 namespace Goteo\Library {
 
 	use Goteo\Core\Model,
+		Goteo\Core\Registry,
         Goteo\Core\Exception;
 	/*
 	 * Clase para sacar textos dinámicos de la tabla text
@@ -99,6 +100,16 @@ namespace Goteo\Library {
 
 			$query = Model::query($sql, $values);
             return $query->fetchObject()->text;
+		}
+
+		/**
+		 * Gettext-like interface for the i18n of interface strings.
+		 *
+		 * @param string $str string to translate
+		 * @return string translated version
+		 */
+		static public function _($str) {
+			return Registry::get('translate')->text($str);
 		}
 
         static public function get ($id) {

--- a/view/header.html.php
+++ b/view/header.html.php
@@ -19,7 +19,7 @@
  */
 
 use Goteo\Library\Text,
-    Goteo\Library\Lang;
+    Goteo\Library\i18n\Lang;
 ?>
 
 <?php include 'view/header/lang.html.php' ?> 

--- a/view/header/lang.html.php
+++ b/view/header/lang.html.php
@@ -18,7 +18,7 @@
  *
  */
 
- use Goteo\Library\Lang;
+ use Goteo\Library\i18n\Lang;
 
 $langs = Lang::getAll(true);
 ?>

--- a/view/prologue.html.php
+++ b/view/prologue.html.php
@@ -74,7 +74,7 @@
   var js, fjs = d.getElementsByTagName(s)[0];
   if (d.getElementById(id)) {return;}
   js = d.createElement(s); js.id = id;
-  js.src = "//connect.facebook.net/<?php echo \Goteo\Library\Lang::locale(); ?>/all.js#xfbml=1&appId=189133314484241";
+  js.src = "//connect.facebook.net/<?php echo \Goteo\Library\i18n\Lang::locale(); ?>/all.js#xfbml=1&appId=189133314484241";
   fjs.parentNode.insertBefore(js, fjs);
 }(document, 'script', 'facebook-jssdk'));</script>
 <?php endif; ?>


### PR DESCRIPTION
I got a few reports that the gettext work that I did, didn't work in all machines. I figured out why and it turns out that using the gettext php module wasn't such a good idea after all. I have now reworked the i18n code to avoid using the module. This version also has a locale fallback mechanism that allows cascading translations. So for example if the locale is set to `nl_BE` (Flemish Dutch), but no actual translation exists for that language but one exists for Dutch `nl` it will fallback to that one.

I had to change some stuff in `common.php` and I added a registry for global access, which isn't per se part of the translation work but it made the code less interdependent.

I also renamed config.php to config.sample.php because I got tired of having my local configuration overwritten.  ;)

This chageset was tested in 4 machines with different OS' and it works better than the last one merged.
