### PR TITLE
I suggest a more dynamic approach to having config files for different e...

### DIFF
--- a/config.php
+++ b/config.php
@@ -1,6 +1,6 @@
 <?php
 /*
- *  Copyright (C) 2012 Platoniq y Fundación Fuentes Abiertas (see README for details)
+ *  Copyright (C) 2012 Platoniq y FundaciÃ³n Fuentes Abiertas (see README for details)
  *	This file is part of Goteo.
  *
  *  Goteo is free software: you can redistribute it and/or modify
@@ -22,205 +22,47 @@ define('GOTEO_PATH', __DIR__ . DIRECTORY_SEPARATOR);
 if (function_exists('ini_set')) {
     ini_set('include_path', GOTEO_PATH . PATH_SEPARATOR . '.');
 } else {
-    throw new Exception("No puedo añadir la API GOTEO al include_path.");
+    throw new Exception("No puedo aÃ±adir la API GOTEO al include_path.");
 }
-
-// Nodo actual
-define('GOTEO_NODE', 'goteo');
 
 define('PEAR', GOTEO_PATH . 'library' . '/' . 'pear' . '/');
 if (function_exists('ini_set')) {
     ini_set('include_path', ini_get('include_path') . PATH_SEPARATOR . PEAR);
 } else {
-    throw new Exception("No puedo añadir las librerías PEAR al include_path.");
+    throw new Exception("No puedo aÃ±adir las librerÃ­as PEAR al include_path.");
 }
-
-/******************************************************
-PhpMailer constants
-*******************************************************/
-if (!defined('PHPMAILER_CLASS')) {
-    define ('PHPMAILER_CLASS', GOTEO_PATH . 'library' . DIRECTORY_SEPARATOR . 'phpmailer' . DIRECTORY_SEPARATOR . 'class.phpmailer.php');
-}
-if (!defined('PHPMAILER_LANGS')) {
-    define ('PHPMAILER_LANGS', GOTEO_PATH . 'library' . DIRECTORY_SEPARATOR . 'phpmailer' . DIRECTORY_SEPARATOR . 'language' . DIRECTORY_SEPARATOR);
-}
-if (!defined('PHPMAILER_SMTP')) {
-    define ('PHPMAILER_SMTP', GOTEO_PATH . 'library' . DIRECTORY_SEPARATOR . 'phpmailer' . DIRECTORY_SEPARATOR . 'class.smtp.php');
-}
-if (!defined('PHPMAILER_POP3')) {
-    define ('PHPMAILER_POP3', GOTEO_PATH . 'library' . DIRECTORY_SEPARATOR . 'phpmailer' . DIRECTORY_SEPARATOR . 'class.pop3.php');
-}
-
-/******************************************************
-OAUTH APP's Secrets
-*******************************************************/
-if (!defined('OAUTH_LIBS')) {
-    define ('OAUTH_LIBS', GOTEO_PATH . 'library' . DIRECTORY_SEPARATOR . 'oauth' . DIRECTORY_SEPARATOR . 'SocialAuth.php');
-}
-
-//Uploads i catxe
-define('GOTEO_DATA_PATH', dirname(__FILE__) . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR);
-
-/**
- * Carga de configuración local si existe
- * Si no se carga el real (si existe)
-**/
-if (file_exists('local-settings.php')) //en .gitignore
-    require 'local-settings.php';
-elseif (file_exists('live-settings.php')) //se considera en git
-    require 'live-settings.php';
-else
-    die(<<<EOF
-No se encuentra el archivo de configuraci&oacute;n <strong>local-settings.php</strong>, debes crear este archivo en la raiz.<br />
-Puedes usar el siguiente c&oacute;digo modificado con los credenciales adecuados.<br />
-<pre>
-&lt;?php
-// Metadata
-define('GOTEO_META_TITLE', '--meta-title--');
-define('GOTEO_META_DESCRIPTION', '--meta-description--');
-define('GOTEO_META_KEYWORDS', '--keywords--');
-define('GOTEO_META_AUTHOR', '--author--');
-define('GOTEO_META_COPYRIGHT', '--copyright--');
-
-//Amazon Web Services Credentials
-define("AWS_KEY", "--------------");
-define("AWS_SECRET", "----------------------------------");
-define("AWS_REGION", "-----------");
-
-//Mail management: ses (amazon), phpmailer (php library)
-define("MAIL_HANDLER", "phpmailer");
-
-// Database
-define('GOTEO_DB_DRIVER', 'mysql');
-define('GOTEO_DB_HOST', 'localhost');
-define('GOTEO_DB_PORT', 3306);
-define('GOTEO_DB_CHARSET', 'UTF-8');
-define('GOTEO_DB_SCHEMA', 'db-schema');
-define('GOTEO_DB_USERNAME', 'db-username');
-define('GOTEO_DB_PASSWORD', 'db-password');
-
-// Mail
-define('GOTEO_MAIL_FROM', 'noreply@example.com');
-define('GOTEO_MAIL_NAME', 'example.com');
-define('GOTEO_MAIL_TYPE', 'smtp'); // mail, sendmail or smtp
-define('GOTEO_MAIL_SMTP_AUTH', true);
-define('GOTEO_MAIL_SMTP_SECURE', 'ssl');
-define('GOTEO_MAIL_SMTP_HOST', 'smtp--host');
-define('GOTEO_MAIL_SMTP_PORT', --portnumber--);
-define('GOTEO_MAIL_SMTP_USERNAME', 'smtp-usermail');
-define('GOTEO_MAIL_SMTP_PASSWORD', 'smtp-password');
-
-define('GOTEO_MAIL', 'info@example.com');
-define('GOTEO_CONTACT_MAIL', 'info@example.com');
-define('GOTEO_FAIL_MAIL', 'fail@example.com');
-define('GOTEO_LOG_MAIL', 'sitelog@example.com');
-
-//Quota de envio máximo para goteo en 24 horas
-define('GOTEO_MAIL_QUOTA', 50000);
-//Quota de envio máximo para newsletters para goteo en 24 horas
-define('GOTEO_MAIL_SENDER_QUOTA', round(GOTEO_MAIL_QUOTA * 0.8));
-//clave de Amazon SNS para recopilar bounces automaticamente: 'arn:aws:sns:us-east-1:XXXXXXXXX:amazon-ses-bounces'
-//la URL de informacion debe ser: goteo_url.tld/aws-sns.php
-define('AWS_SNS_CLIENT_ID', 'XXXXXXXXX');
-define('AWS_SNS_REGION', 'us-east-1');
-define('AWS_SNS_BOUNCES_TOPIC', 'amazon-ses-bounces');
-define('AWS_SNS_COMPLAINTS_TOPIC', 'amazon-ses-complaints');
-
-// Language
-define('GOTEO_DEFAULT_LANG', 'en');
-// name of the gettext .po file (used for admin only texts at the moment)
-define('GOTEO_GETTEXT_DOMAIN', 'messages');
-// gettext files are cached, to reload a new one requires to restart Apache which is stupid (and annoying while 
-//	developing) this setting tells the langueage code to bypass caching by using a clever file-renaming 
-// mechanism described in http://blog.ghost3k.net/articles/php/11/gettext-caching-in-php
-define('GOTEO_GETTEXT_BYPASS_CACHING', true);
-
-// url
-define('SITE_URL', 'http://example.com'); // endpoint url
-define('SRC_URL', 'http://example.com');  // host for statics
-define('SEC_URL', 'http://example.com');  // with SSL certified
-
-//Sessions
-//session handler: php, dynamodb
-define("SESSION_HANDLER", "php");
-
-//Files management: s3, file
-define("FILE_HANDLER", "file");
-
-//Log file management: s3, file
-define("LOG_HANDLER", "file");
 
 // environment: local, beta, real
 define("GOTEO_ENV", "local");
 
-//S3 bucket (if you set FILE_HANDLER to s3)
-define("AWS_S3_BUCKET", "static.example.com");
-define("AWS_S3_PREFIX", "");
+$configPath = __DIR__.'/config/';
 
-//bucket para logs (if you set LOG_HANDLER to s3)
-define("AWS_S3_LOG_BUCKET", "bucket");
-define("AWS_S3_LOG_PREFIX", "applogs/");
+/**
+ * Load config files spe
+ */
+switch ($_SERVER['SERVER_NAME']) {
+    // Local envirnonment config files
+    case 'localhost':
+    case 'local.goteo.com':
+        $envPath = __DIR__.'/config/local/';
+        break;
 
-// Cron params (for cron processes using wget)
-define('CRON_PARAM', '--------------');
-define('CRON_VALUE', '--------------');
+    // Live envirnoment config files
+    case 'goteo.com':
+    case 'www.goteo.com':
+    default:
+        $envPath = __DIR__.'/config/';
+        break;
+}
 
-
-/****************************************************
-Paypal constants (sandbox)
-* Must set cretentials on library/paypal/paypal_config.php as well
-****************************************************/
-define('PAYPAL_REDIRECT_URL', '---Sandbox/Production-url-----https://www.sandbox.paypal.com/webscr&cmd=');
-define('PAYPAL_DEVELOPER_PORTAL', '--developper-domain--');
-define('PAYPAL_DEVICE_ID', '--domain--');
-define('PAYPAL_APPLICATION_ID', '--PayPal-app-Id---');
-define('PAYPAL_BUSINESS_ACCOUNT', '--mail-like-paypal-account--');
-define('PAYPAL_IP_ADDRESS', '127.0.0.1');
-
-/****************************************************
-TPV [Bank Name] (depends on your bank)
-****************************************************/
-define('TPV_MERCHANT_CODE', 'xxxxxxxxx');
-define('TPV_REDIRECT_URL', '--bank-rest-api-url--');
-define('TPV_ENCRYPT_KEY', 'xxxxxxxxx');
-
-/*
-Any other payment system configuration should be setted here
-*/
-
-/****************************************************
-Social Services constants  (needed to login-with on the controller/user and library/oauth)
-****************************************************/
-// Credentials Facebook app
-define('OAUTH_FACEBOOK_ID', '-----------------------------------'); //
-define('OAUTH_FACEBOOK_SECRET', '-----------------------------------'); //
-
-// Credentials Twitter app
-define('OAUTH_TWITTER_ID', '-----------------------------------'); //
-define('OAUTH_TWITTER_SECRET', '-----------------------------------'); //
-
-// Credentials Linkedin app
-define('OAUTH_LINKEDIN_ID', '-----------------------------------'); //
-define('OAUTH_LINKEDIN_SECRET', '-----------------------------------'); //
-
-// Un secreto inventado cualquiera para encriptar los emails que sirven de secreto en openid
-define('OAUTH_OPENID_SECRET','-----------------------------------');
-
-// recaptcha ( to be used in /contact form )
-define('RECAPTCHA_PUBLIC_KEY','-----------------------------------');
-define('RECAPTCHA_PRIVATE_KEY','-----------------------------------');
-
-/****************************************************
-Google Analytics
-****************************************************/
-define('GOTEO_ANALYTICS_TRACKER', "<script type=\"text/javascript\">
-__your_tracking_js_code_goes_here___
-</script>
-");
-?&gt;
-</pre>
-EOF
-);
+$configFiles = ['app', 'mail', 'database', 'apis', 'meta'];
+foreach ($configFiles as $configFile) {
+    if (file_exists($envPath.$configFile.'.php')) {
+        require $envPath.$configFile.'.php';
+    } else {
+        require $configPath.$configFile.'.php';
+    }
+}
 
 if (file_exists('tmp-settings.php'))
     require 'tmp-settings.php';

--- a/config/apis.php
+++ b/config/apis.php
@@ -1,0 +1,74 @@
+<?php
+
+/******************************************************
+OAUTH APP's Secrets
+*******************************************************/
+if (!defined('OAUTH_LIBS')) {
+    define ('OAUTH_LIBS', GOTEO_PATH . 'library' . DIRECTORY_SEPARATOR . 'oauth' . DIRECTORY_SEPARATOR . 'SocialAuth.php');
+}
+
+//Amazon Web Services Credentials
+define("AWS_KEY", "--------------");
+define("AWS_SECRET", "----------------------------------");
+define("AWS_REGION", "-----------");
+
+//clave de Amazon SNS para recopilar bounces automaticamente: 'arn:aws:sns:us-east-1:XXXXXXXXX:amazon-ses-bounces'
+//la URL de informacion debe ser: goteo_url.tld/aws-sns.php
+define('AWS_SNS_CLIENT_ID', 'XXXXXXXXX');
+define('AWS_SNS_REGION', 'us-east-1');
+define('AWS_SNS_BOUNCES_TOPIC', 'amazon-ses-bounces');
+define('AWS_SNS_COMPLAINTS_TOPIC', 'amazon-ses-complaints');
+
+
+//S3 bucket (if you set FILE_HANDLER to s3)
+define("AWS_S3_BUCKET", "static.example.com");
+define("AWS_S3_PREFIX", "");
+
+//bucket para logs (if you set LOG_HANDLER to s3)
+define("AWS_S3_LOG_BUCKET", "bucket");
+define("AWS_S3_LOG_PREFIX", "applogs/");
+
+
+/****************************************************
+Paypal constants (sandbox)
+* Must set cretentials on library/paypal/paypal_config.php as well
+****************************************************/
+define('PAYPAL_REDIRECT_URL', '---Sandbox/Production-url-----https://www.sandbox.paypal.com/webscr&cmd=');
+define('PAYPAL_DEVELOPER_PORTAL', '--developper-domain--');
+define('PAYPAL_DEVICE_ID', '--domain--');
+define('PAYPAL_APPLICATION_ID', '--PayPal-app-Id---');
+define('PAYPAL_BUSINESS_ACCOUNT', '--mail-like-paypal-account--');
+define('PAYPAL_IP_ADDRESS', '127.0.0.1');
+
+/****************************************************
+TPV [Bank Name] (depends on your bank)
+****************************************************/
+define('TPV_MERCHANT_CODE', 'xxxxxxxxx');
+define('TPV_REDIRECT_URL', '--bank-rest-api-url--');
+define('TPV_ENCRYPT_KEY', 'xxxxxxxxx');
+
+/*
+Any other payment system configuration should be setted here
+*/
+
+/****************************************************
+Social Services constants  (needed to login-with on the controller/user and library/oauth)
+****************************************************/
+// Credentials Facebook app
+define('OAUTH_FACEBOOK_ID', '-----------------------------------'); //
+define('OAUTH_FACEBOOK_SECRET', '-----------------------------------'); //
+
+// Credentials Twitter app
+define('OAUTH_TWITTER_ID', '-----------------------------------'); //
+define('OAUTH_TWITTER_SECRET', '-----------------------------------'); //
+
+// Credentials Linkedin app
+define('OAUTH_LINKEDIN_ID', '-----------------------------------'); //
+define('OAUTH_LINKEDIN_SECRET', '-----------------------------------'); //
+
+// Un secreto inventado cualquiera para encriptar los emails que sirven de secreto en openid
+define('OAUTH_OPENID_SECRET','-----------------------------------');
+
+// recaptcha ( to be used in /contact form )
+define('RECAPTCHA_PUBLIC_KEY','-----------------------------------');
+define('RECAPTCHA_PRIVATE_KEY','-----------------------------------');

--- a/config/app.php
+++ b/config/app.php
@@ -1,0 +1,37 @@
+<?php
+
+// Nodo actual
+define('GOTEO_NODE', 'goteo');
+
+//Upload and cache directory path
+define('GOTEO_DATA_PATH', dirname(__FILE__) . DIRECTORY_SEPARATOR . 'data' . DIRECTORY_SEPARATOR);
+
+// Language
+define('GOTEO_DEFAULT_LANG', 'en');
+// name of the gettext .po file (used for admin only texts at the moment)
+define('GOTEO_GETTEXT_DOMAIN', 'messages');
+// gettext files are cached, to reload a new one requires to restart Apache which is stupid (and annoying while 
+//	developing) this setting tells the langueage code to bypass caching by using a clever file-renaming 
+// mechanism described in http://blog.ghost3k.net/articles/php/11/gettext-caching-in-php
+define('GOTEO_GETTEXT_BYPASS_CACHING', true);
+
+// url
+define('SITE_URL', 'http://example.com'); // endpoint url
+define('SRC_URL',  'http://example.com');  // host for statics
+define('SEC_URL',  'http://example.com');  // with SSL certified
+
+//Sessions
+//session handler: php, dynamodb
+define("SESSION_HANDLER", "php");
+
+//Files management: s3, file
+define("FILE_HANDLER", "file");
+
+//Log file management: s3, file
+define("LOG_HANDLER", "file");
+
+// Cron params (for cron processes using wget)
+define('CRON_PARAM', '--------------');
+define('CRON_VALUE', '--------------');
+
+define('GOTEO_ANALYTICS_TRACKER', 'UA-XXXXX-X');

--- a/config/database.php
+++ b/config/database.php
@@ -1,0 +1,10 @@
+<?php
+
+// Database
+define('GOTEO_DB_DRIVER',   'mysql');
+define('GOTEO_DB_HOST',     'localhost');
+define('GOTEO_DB_PORT',     3306);
+define('GOTEO_DB_CHARSET',  'UTF-8');
+define('GOTEO_DB_SCHEMA',   'db-schema');
+define('GOTEO_DB_USERNAME', 'db-username');
+define('GOTEO_DB_PASSWORD', 'db-password');

--- a/config/mail.php
+++ b/config/mail.php
@@ -1,0 +1,42 @@
+<?php
+
+/******************************************************
+PhpMailer constants
+*******************************************************/
+if (!defined('PHPMAILER_CLASS')) {
+    define ('PHPMAILER_CLASS', GOTEO_PATH . 'library' . DIRECTORY_SEPARATOR . 'phpmailer' . DIRECTORY_SEPARATOR . 'class.phpmailer.php');
+}
+if (!defined('PHPMAILER_LANGS')) {
+    define ('PHPMAILER_LANGS', GOTEO_PATH . 'library' . DIRECTORY_SEPARATOR . 'phpmailer' . DIRECTORY_SEPARATOR . 'language' . DIRECTORY_SEPARATOR);
+}
+if (!defined('PHPMAILER_SMTP')) {
+    define ('PHPMAILER_SMTP', GOTEO_PATH . 'library' . DIRECTORY_SEPARATOR . 'phpmailer' . DIRECTORY_SEPARATOR . 'class.smtp.php');
+}
+if (!defined('PHPMAILER_POP3')) {
+    define ('PHPMAILER_POP3', GOTEO_PATH . 'library' . DIRECTORY_SEPARATOR . 'phpmailer' . DIRECTORY_SEPARATOR . 'class.pop3.php');
+}
+
+//Mail management: ses (amazon), phpmailer (php library)
+define("MAIL_HANDLER", "phpmailer");
+
+// Mail
+define('GOTEO_MAIL_FROM', 'noreply@example.com');
+define('GOTEO_MAIL_NAME', 'example.com');
+define('GOTEO_MAIL_TYPE', 'smtp'); // mail, sendmail or smtp
+
+define('GOTEO_MAIL_SMTP_AUTH',     true);
+define('GOTEO_MAIL_SMTP_SECURE',   'ssl');
+define('GOTEO_MAIL_SMTP_HOST',     'smtp--host');
+define('GOTEO_MAIL_SMTP_PORT',     25); // Default smpt port
+define('GOTEO_MAIL_SMTP_USERNAME', 'smtp-usermail');
+define('GOTEO_MAIL_SMTP_PASSWORD', 'smtp-password');
+
+define('GOTEO_MAIL',         'info@example.com');
+define('GOTEO_CONTACT_MAIL', 'info@example.com');
+define('GOTEO_FAIL_MAIL',    'fail@example.com');
+define('GOTEO_LOG_MAIL',     'sitelog@example.com');
+
+//Quota de envio máximo para goteo en 24 horas
+define('GOTEO_MAIL_QUOTA', 50000);
+//Quota de envio máximo para newsletters para goteo en 24 horas
+define('GOTEO_MAIL_SENDER_QUOTA', round(GOTEO_MAIL_QUOTA * 0.8));

--- a/config/meta.php
+++ b/config/meta.php
@@ -1,0 +1,8 @@
+<?php
+
+// Metadata
+define('GOTEO_META_TITLE', '--meta-title--');
+define('GOTEO_META_DESCRIPTION', '--meta-description--');
+define('GOTEO_META_KEYWORDS', '--keywords--');
+define('GOTEO_META_AUTHOR', '--author--');
+define('GOTEO_META_COPYRIGHT', '--copyright--');


### PR DESCRIPTION
...nvironments.

In the code suggested, there will be default config files in `config/` folder, but if you want to have config files, only for a specific environment (environments are analyzed through the `$_SERVER['SERVER_NAME']` variable), you will only have to adjust the switch that start at `config.php:44`, by adding you case.

For example:
  On local environments, I always create a host called local.project.com (in this case, local.goteo.com), and if I ever want to have specific configuration only for a specific config file (usually is always database.php file), I just create a `local/` directory inside `config/` directory, and copy `database.php` there. Then I just modify the parameters to suit my local configuration for my database.

NOTE*: If `config/local/database.php` does not exist, or any other local environment config file, it will load the one in the main config folder.

Signed-off-by: Alexandru Budurovici w0rldart@w0rldart.com
